### PR TITLE
geom_alt props

### DIFF
--- a/data/421/166/807/421166807.geojson
+++ b/data/421/166/807/421166807.geojson
@@ -111,6 +111,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459008703,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9234365b2e12b6487369660676ac0fe8",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
         }
     ],
     "wof:id":421166807,
-    "wof:lastmodified":1566681788,
+    "wof:lastmodified":1582346797,
     "wof:name":"Goa",
     "wof:parent_id":1108697659,
     "wof:placetype":"locality",

--- a/data/421/167/495/421167495.geojson
+++ b/data/421/167/495/421167495.geojson
@@ -149,6 +149,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459008734,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"71342af3b9880cc88d2fb67a0f6dad7f",
     "wof:hierarchy":[
         {
@@ -160,7 +163,7 @@
         }
     ],
     "wof:id":421167495,
-    "wof:lastmodified":1566681802,
+    "wof:lastmodified":1582346797,
     "wof:name":"New Lucena",
     "wof:parent_id":1108698575,
     "wof:placetype":"locality",

--- a/data/421/167/971/421167971.geojson
+++ b/data/421/167/971/421167971.geojson
@@ -86,6 +86,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459008750,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f3a8bab2f8361c995bb0dc86dbe9ffae",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
         }
     ],
     "wof:id":421167971,
-    "wof:lastmodified":1566681801,
+    "wof:lastmodified":1582346797,
     "wof:name":"Bambang",
     "wof:parent_id":1108697095,
     "wof:placetype":"locality",

--- a/data/421/167/993/421167993.geojson
+++ b/data/421/167/993/421167993.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459008750,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0f832ba045d3bca8baeffbc90f62909b",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421167993,
-    "wof:lastmodified":1566681801,
+    "wof:lastmodified":1582346797,
     "wof:name":"Manapla",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/169/759/421169759.geojson
+++ b/data/421/169/759/421169759.geojson
@@ -269,6 +269,7 @@
     "qs:woe_id":1187094,
     "src:geom":"quattroshapes",
     "src:geom_alt":[
+        "naturalearth",
         "quattroshapes_pg"
     ],
     "wof:belongsto":[
@@ -286,6 +287,10 @@
     },
     "wof:country":"PH",
     "wof:created":1459008823,
+    "wof:geom_alt":[
+        "naturalearth",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7873ef6619de8125f0d63ae0e6013e25",
     "wof:hierarchy":[
         {
@@ -296,7 +301,7 @@
         }
     ],
     "wof:id":421169759,
-    "wof:lastmodified":1561778702,
+    "wof:lastmodified":1582346797,
     "wof:name":"Pasay City",
     "wof:parent_id":1159397243,
     "wof:placetype":"locality",

--- a/data/421/170/461/421170461.geojson
+++ b/data/421/170/461/421170461.geojson
@@ -210,6 +210,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459008854,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"48615dca43ad250565d4466c8ce845a5",
     "wof:hierarchy":[
         {
@@ -220,7 +223,7 @@
         }
     ],
     "wof:id":421170461,
-    "wof:lastmodified":1566681862,
+    "wof:lastmodified":1582346799,
     "wof:name":"Dasmari\u00f1as",
     "wof:parent_id":1159397243,
     "wof:placetype":"locality",

--- a/data/421/170/823/421170823.geojson
+++ b/data/421/170/823/421170823.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459008870,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9a6a4dfb1a35efa0ad37f012b9f7484c",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
         }
     ],
     "wof:id":421170823,
-    "wof:lastmodified":1566681861,
+    "wof:lastmodified":1582346799,
     "wof:name":"Badoc",
     "wof:parent_id":1108696879,
     "wof:placetype":"locality",

--- a/data/421/170/923/421170923.geojson
+++ b/data/421/170/923/421170923.geojson
@@ -125,6 +125,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459008874,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e86f41f8b0ef24123c8e7b8338934a2a",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":421170923,
-    "wof:lastmodified":1566681861,
+    "wof:lastmodified":1582346799,
     "wof:name":"Pandan",
     "wof:parent_id":1108698775,
     "wof:placetype":"locality",

--- a/data/421/171/027/421171027.geojson
+++ b/data/421/171/027/421171027.geojson
@@ -112,6 +112,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459008879,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ea825a59249709e95aa0b4b0cbdca9ed",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421171027,
-    "wof:lastmodified":1566681882,
+    "wof:lastmodified":1582346799,
     "wof:name":"San Juan",
     "wof:parent_id":1108699219,
     "wof:placetype":"locality",

--- a/data/421/172/855/421172855.geojson
+++ b/data/421/172/855/421172855.geojson
@@ -155,6 +155,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459008957,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"faf778fe605c93cc6308b17386459de9",
     "wof:hierarchy":[
         {
@@ -166,7 +169,7 @@
         }
     ],
     "wof:id":421172855,
-    "wof:lastmodified":1566681831,
+    "wof:lastmodified":1582346798,
     "wof:name":"Las Pi\u00f1as",
     "wof:parent_id":1108698853,
     "wof:placetype":"locality",

--- a/data/421/173/365/421173365.geojson
+++ b/data/421/173/365/421173365.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459008980,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a83499624aa0b61bd6b0c008e6e73133",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":421173365,
-    "wof:lastmodified":1566681825,
+    "wof:lastmodified":1582346798,
     "wof:name":"Matan-ao",
     "wof:parent_id":1108697703,
     "wof:placetype":"locality",

--- a/data/421/173/373/421173373.geojson
+++ b/data/421/173/373/421173373.geojson
@@ -298,6 +298,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459008980,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d8a40c4d338f44f30a2b4392b8b4edd8",
     "wof:hierarchy":[
         {
@@ -309,7 +312,7 @@
         }
     ],
     "wof:id":421173373,
-    "wof:lastmodified":1566681826,
+    "wof:lastmodified":1582346798,
     "wof:name":"Lian",
     "wof:parent_id":1108696553,
     "wof:placetype":"locality",

--- a/data/421/173/375/421173375.geojson
+++ b/data/421/173/375/421173375.geojson
@@ -65,6 +65,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459008980,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dfc5b8974135d67a3ad2de5b436c966c",
     "wof:hierarchy":[
         {
@@ -76,7 +79,7 @@
         }
     ],
     "wof:id":421173375,
-    "wof:lastmodified":1566681826,
+    "wof:lastmodified":1582346798,
     "wof:name":"Matnog",
     "wof:parent_id":1108696709,
     "wof:placetype":"locality",

--- a/data/421/174/553/421174553.geojson
+++ b/data/421/174/553/421174553.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009036,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"47323b260362a31ed754c4ed05f506e2",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":421174553,
-    "wof:lastmodified":1566681818,
+    "wof:lastmodified":1582346798,
     "wof:name":"Alcantara",
     "wof:parent_id":1108696607,
     "wof:placetype":"locality",

--- a/data/421/174/687/421174687.geojson
+++ b/data/421/174/687/421174687.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009040,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4a8b331ec4fe32ed22121d47b58e9934",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":421174687,
-    "wof:lastmodified":1566681816,
+    "wof:lastmodified":1582346798,
     "wof:name":"Calamba",
     "wof:parent_id":1108697199,
     "wof:placetype":"locality",

--- a/data/421/174/715/421174715.geojson
+++ b/data/421/174/715/421174715.geojson
@@ -118,6 +118,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009041,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"84b7920966315fccfc91e68c91e4dfd1",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421174715,
-    "wof:lastmodified":1566681818,
+    "wof:lastmodified":1582346798,
     "wof:name":"Placer",
     "wof:parent_id":1108698917,
     "wof:placetype":"locality",

--- a/data/421/174/855/421174855.geojson
+++ b/data/421/174/855/421174855.geojson
@@ -91,6 +91,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009046,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f8053aa441d89bf1227261bf870955ab",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":421174855,
-    "wof:lastmodified":1566681819,
+    "wof:lastmodified":1582346798,
     "wof:name":"Catarman",
     "wof:parent_id":1108697465,
     "wof:placetype":"locality",

--- a/data/421/175/361/421175361.geojson
+++ b/data/421/175/361/421175361.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009064,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f3efacda08fb6e5fb30d9a62ebb64d1a",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421175361,
-    "wof:lastmodified":1566681835,
+    "wof:lastmodified":1582346798,
     "wof:name":"Manay",
     "wof:parent_id":1108698343,
     "wof:placetype":"locality",

--- a/data/421/175/487/421175487.geojson
+++ b/data/421/175/487/421175487.geojson
@@ -122,6 +122,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009069,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"191219ce4caf078b7027c4993b631e41",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421175487,
-    "wof:lastmodified":1566681836,
+    "wof:lastmodified":1582346798,
     "wof:name":"Cordova",
     "wof:parent_id":1108698607,
     "wof:placetype":"locality",

--- a/data/421/175/489/421175489.geojson
+++ b/data/421/175/489/421175489.geojson
@@ -206,6 +206,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009069,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6254c559ea4ae0a9ffb739bc1e886560",
     "wof:hierarchy":[
         {
@@ -217,7 +220,7 @@
         }
     ],
     "wof:id":421175489,
-    "wof:lastmodified":1566681837,
+    "wof:lastmodified":1582346798,
     "wof:name":"Meycauayan",
     "wof:parent_id":1108698467,
     "wof:placetype":"locality",

--- a/data/421/176/251/421176251.geojson
+++ b/data/421/176/251/421176251.geojson
@@ -130,6 +130,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009102,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ef72907714a9f1cd0a0b96e5f71c610f",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
         }
     ],
     "wof:id":421176251,
-    "wof:lastmodified":1566681881,
+    "wof:lastmodified":1582346799,
     "wof:name":"Mataasnakahoy",
     "wof:parent_id":1108698423,
     "wof:placetype":"locality",

--- a/data/421/176/685/421176685.geojson
+++ b/data/421/176/685/421176685.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009116,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"32254a934892d06ca2004bd48488f81f",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":421176685,
-    "wof:lastmodified":1566681881,
+    "wof:lastmodified":1582346799,
     "wof:name":"Makilala",
     "wof:parent_id":1108697111,
     "wof:placetype":"locality",

--- a/data/421/178/101/421178101.geojson
+++ b/data/421/178/101/421178101.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009171,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e48fd7ab10625a4616a7e701469c68f8",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":421178101,
-    "wof:lastmodified":1566681873,
+    "wof:lastmodified":1582346799,
     "wof:name":"Borbon",
     "wof:parent_id":1108697059,
     "wof:placetype":"locality",

--- a/data/421/178/117/421178117.geojson
+++ b/data/421/178/117/421178117.geojson
@@ -115,6 +115,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009171,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1513f1944924c214faf171f76c0a356d",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421178117,
-    "wof:lastmodified":1566681872,
+    "wof:lastmodified":1582346799,
     "wof:name":"Esperanza",
     "wof:parent_id":1108698675,
     "wof:placetype":"locality",

--- a/data/421/179/855/421179855.geojson
+++ b/data/421/179/855/421179855.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009235,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"98c67fb59dad795611589c357ebd40cc",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":421179855,
-    "wof:lastmodified":1566681867,
+    "wof:lastmodified":1582346799,
     "wof:name":"Miagao",
     "wof:parent_id":1108699337,
     "wof:placetype":"locality",

--- a/data/421/181/427/421181427.geojson
+++ b/data/421/181/427/421181427.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009296,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6eaae62a8a58c8b0318e5580f9e3d81c",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421181427,
-    "wof:lastmodified":1566681834,
+    "wof:lastmodified":1582346798,
     "wof:name":"Anahawan",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/182/291/421182291.geojson
+++ b/data/421/182/291/421182291.geojson
@@ -158,6 +158,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009325,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"134d16d17dce8b579b5eb82f7f9522fe",
     "wof:hierarchy":[
         {
@@ -169,7 +172,7 @@
         }
     ],
     "wof:id":421182291,
-    "wof:lastmodified":1566681879,
+    "wof:lastmodified":1582346799,
     "wof:name":"Union",
     "wof:parent_id":1108698299,
     "wof:placetype":"locality",

--- a/data/421/182/697/421182697.geojson
+++ b/data/421/182/697/421182697.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009339,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b960368ef2ef2c2ab42093fb474ec686",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":421182697,
-    "wof:lastmodified":1566681879,
+    "wof:lastmodified":1582346799,
     "wof:name":"Bauan",
     "wof:parent_id":1108696955,
     "wof:placetype":"locality",

--- a/data/421/183/363/421183363.geojson
+++ b/data/421/183/363/421183363.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009367,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"169bf8a24a799ca9916e73aeaacba66a",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421183363,
-    "wof:lastmodified":1566681864,
+    "wof:lastmodified":1582346799,
     "wof:name":"Alegria",
     "wof:parent_id":1108697933,
     "wof:placetype":"locality",

--- a/data/421/185/595/421185595.geojson
+++ b/data/421/185/595/421185595.geojson
@@ -60,6 +60,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009448,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"890ef6d5e6ac6988d807bc250f7ddb0b",
     "wof:hierarchy":[
         {
@@ -71,7 +74,7 @@
         }
     ],
     "wof:id":421185595,
-    "wof:lastmodified":1566681882,
+    "wof:lastmodified":1582346799,
     "wof:name":"Larap",
     "wof:parent_id":1108697845,
     "wof:placetype":"locality",

--- a/data/421/185/727/421185727.geojson
+++ b/data/421/185/727/421185727.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009452,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c6dc1cb96e4209e5e100486c21b3afb9",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421185727,
-    "wof:lastmodified":1566681883,
+    "wof:lastmodified":1582346799,
     "wof:name":"Nueva Valencia",
     "wof:parent_id":1108697081,
     "wof:placetype":"locality",

--- a/data/421/185/743/421185743.geojson
+++ b/data/421/185/743/421185743.geojson
@@ -135,6 +135,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009453,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3c65541939588e955ff124cd0c3ead8c",
     "wof:hierarchy":[
         {
@@ -146,7 +149,7 @@
         }
     ],
     "wof:id":421185743,
-    "wof:lastmodified":1566681883,
+    "wof:lastmodified":1582346799,
     "wof:name":"Bulacan",
     "wof:parent_id":1108697101,
     "wof:placetype":"locality",

--- a/data/421/186/141/421186141.geojson
+++ b/data/421/186/141/421186141.geojson
@@ -278,6 +278,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009471,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"1584a6fd56c24e6fb8d7e5495523afe0",
     "wof:hierarchy":[
         {
@@ -289,7 +292,7 @@
         }
     ],
     "wof:id":421186141,
-    "wof:lastmodified":1566681833,
+    "wof:lastmodified":1582346798,
     "wof:name":"Dagupan",
     "wof:parent_id":1108698951,
     "wof:placetype":"locality",

--- a/data/421/187/677/421187677.geojson
+++ b/data/421/187/677/421187677.geojson
@@ -214,6 +214,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009520,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4803dbe5ddfd50915ee687a1f0daf27d",
     "wof:hierarchy":[
         {
@@ -225,7 +228,7 @@
         }
     ],
     "wof:id":421187677,
-    "wof:lastmodified":1566681824,
+    "wof:lastmodified":1582346798,
     "wof:name":"Samal",
     "wof:parent_id":1108699097,
     "wof:placetype":"locality",

--- a/data/421/189/321/421189321.geojson
+++ b/data/421/189/321/421189321.geojson
@@ -122,6 +122,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009617,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3aae9859fb8df4a0bc48e9cac536f772",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421189321,
-    "wof:lastmodified":1566681829,
+    "wof:lastmodified":1582346798,
     "wof:name":"Tagudin",
     "wof:parent_id":1108698195,
     "wof:placetype":"locality",

--- a/data/421/189/423/421189423.geojson
+++ b/data/421/189/423/421189423.geojson
@@ -127,6 +127,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009624,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"eda8ee744cba1da1485a4091c692482f",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":421189423,
-    "wof:lastmodified":1566681827,
+    "wof:lastmodified":1582346798,
     "wof:name":"Catarman",
     "wof:parent_id":1108697327,
     "wof:placetype":"locality",

--- a/data/421/189/437/421189437.geojson
+++ b/data/421/189/437/421189437.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009625,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"80d8a7c2bd3567b7326da00b4cf0d199",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421189437,
-    "wof:lastmodified":1566681827,
+    "wof:lastmodified":1582346798,
     "wof:name":"Cuenca",
     "wof:parent_id":1108697401,
     "wof:placetype":"locality",

--- a/data/421/189/439/421189439.geojson
+++ b/data/421/189/439/421189439.geojson
@@ -148,6 +148,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009625,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"99461d73c1d1ffcd7134b7c4e2ebd378",
     "wof:hierarchy":[
         {
@@ -159,7 +162,7 @@
         }
     ],
     "wof:id":421189439,
-    "wof:lastmodified":1566681827,
+    "wof:lastmodified":1582346798,
     "wof:name":"Daet",
     "wof:parent_id":1108697417,
     "wof:placetype":"locality",

--- a/data/421/189/447/421189447.geojson
+++ b/data/421/189/447/421189447.geojson
@@ -323,6 +323,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009625,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"11f148bd1340d04f6e6c2b29421d4c38",
     "wof:hierarchy":[
         {
@@ -334,7 +337,7 @@
         }
     ],
     "wof:id":421189447,
-    "wof:lastmodified":1566681826,
+    "wof:lastmodified":1582346798,
     "wof:name":"Legazpi City",
     "wof:parent_id":1108698043,
     "wof:placetype":"locality",

--- a/data/421/190/875/421190875.geojson
+++ b/data/421/190/875/421190875.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009672,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5da7a4ade5d14ecea77f51e224d9b784",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":421190875,
-    "wof:lastmodified":1566681847,
+    "wof:lastmodified":1582346798,
     "wof:name":"Talibon",
     "wof:parent_id":1108699261,
     "wof:placetype":"locality",

--- a/data/421/191/697/421191697.geojson
+++ b/data/421/191/697/421191697.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009702,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8fa8c401e072c7e5481ab7bf0157ea2b",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":421191697,
-    "wof:lastmodified":1566681846,
+    "wof:lastmodified":1582346798,
     "wof:name":"Jordan",
     "wof:parent_id":1108697837,
     "wof:placetype":"locality",

--- a/data/421/192/527/421192527.geojson
+++ b/data/421/192/527/421192527.geojson
@@ -131,6 +131,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009739,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9724428e85367170f8c554520536b52d",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
         }
     ],
     "wof:id":421192527,
-    "wof:lastmodified":1566681790,
+    "wof:lastmodified":1582346797,
     "wof:name":"San Rafael",
     "wof:parent_id":1108698593,
     "wof:placetype":"locality",

--- a/data/421/192/581/421192581.geojson
+++ b/data/421/192/581/421192581.geojson
@@ -350,6 +350,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009741,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"86613a07d78dd8835592e20d24f5898b",
     "wof:hierarchy":[
         {
@@ -361,7 +364,7 @@
         }
     ],
     "wof:id":421192581,
-    "wof:lastmodified":1566681789,
+    "wof:lastmodified":1582346797,
     "wof:name":"Baguio City",
     "wof:parent_id":1108696789,
     "wof:placetype":"locality",

--- a/data/421/192/673/421192673.geojson
+++ b/data/421/192/673/421192673.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009744,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"37a0d4ed9e8dd3cd67ed59a04983a33c",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":421192673,
-    "wof:lastmodified":1566681789,
+    "wof:lastmodified":1582346797,
     "wof:name":"Calauan",
     "wof:parent_id":1108698231,
     "wof:placetype":"locality",

--- a/data/421/192/677/421192677.geojson
+++ b/data/421/192/677/421192677.geojson
@@ -93,6 +93,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009745,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"70ecb63a7f1ce4fcd14098d45c7095c3",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421192677,
-    "wof:lastmodified":1566681791,
+    "wof:lastmodified":1582346797,
     "wof:name":"Quiapo District",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/192/759/421192759.geojson
+++ b/data/421/192/759/421192759.geojson
@@ -262,6 +262,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009747,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cba410daf0846f7ffc09e78b1971cbd6",
     "wof:hierarchy":[
         {
@@ -273,7 +276,7 @@
         }
     ],
     "wof:id":421192759,
-    "wof:lastmodified":1566681790,
+    "wof:lastmodified":1582346797,
     "wof:name":"Tuburan",
     "wof:parent_id":1108699863,
     "wof:placetype":"locality",

--- a/data/421/192/761/421192761.geojson
+++ b/data/421/192/761/421192761.geojson
@@ -307,6 +307,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009748,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d2312f1b3fc7c7d10365b443ee4d5a4c",
     "wof:hierarchy":[
         {
@@ -318,7 +321,7 @@
         }
     ],
     "wof:id":421192761,
-    "wof:lastmodified":1566681790,
+    "wof:lastmodified":1582346797,
     "wof:name":"Ubay",
     "wof:parent_id":1108697369,
     "wof:placetype":"locality",

--- a/data/421/192/841/421192841.geojson
+++ b/data/421/192/841/421192841.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009750,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3ed830a2a8a315c789cadb627c3cf6f5",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421192841,
-    "wof:lastmodified":1566681790,
+    "wof:lastmodified":1582346797,
     "wof:name":"Maitum",
     "wof:parent_id":1108698277,
     "wof:placetype":"locality",

--- a/data/421/192/983/421192983.geojson
+++ b/data/421/192/983/421192983.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009755,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c151daebcb6268ee2e783df960b873aa",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":421192983,
-    "wof:lastmodified":1566681789,
+    "wof:lastmodified":1582346797,
     "wof:name":"San Pablo",
     "wof:parent_id":1108699291,
     "wof:placetype":"locality",

--- a/data/421/193/405/421193405.geojson
+++ b/data/421/193/405/421193405.geojson
@@ -65,6 +65,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009770,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8f8b4c87a7934b310d55fbed9852839a",
     "wof:hierarchy":[
         {
@@ -75,7 +78,7 @@
         }
     ],
     "wof:id":421193405,
-    "wof:lastmodified":1566681800,
+    "wof:lastmodified":1582346797,
     "wof:name":"Bayanan",
     "wof:parent_id":1159397243,
     "wof:placetype":"locality",

--- a/data/421/193/845/421193845.geojson
+++ b/data/421/193/845/421193845.geojson
@@ -145,6 +145,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009785,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"43c2a5089f80f764aee70081b9806349",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
         }
     ],
     "wof:id":421193845,
-    "wof:lastmodified":1566681798,
+    "wof:lastmodified":1582346797,
     "wof:name":"Iba",
     "wof:parent_id":1108699699,
     "wof:placetype":"locality",

--- a/data/421/193/847/421193847.geojson
+++ b/data/421/193/847/421193847.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009785,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a685984df578585e14b7d2d9091a0fce",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":421193847,
-    "wof:lastmodified":1566681799,
+    "wof:lastmodified":1582346797,
     "wof:name":"Consolacion",
     "wof:parent_id":1108697383,
     "wof:placetype":"locality",

--- a/data/421/194/091/421194091.geojson
+++ b/data/421/194/091/421194091.geojson
@@ -237,6 +237,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009794,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5904035acc641af84eed7c21daf97ffd",
     "wof:hierarchy":[
         {
@@ -248,7 +251,7 @@
         }
     ],
     "wof:id":421194091,
-    "wof:lastmodified":1566681794,
+    "wof:lastmodified":1582346797,
     "wof:name":"Cavite City",
     "wof:parent_id":1108698605,
     "wof:placetype":"locality",

--- a/data/421/194/241/421194241.geojson
+++ b/data/421/194/241/421194241.geojson
@@ -62,6 +62,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009799,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"014bb659f7cb3c65c8e311e289537e59",
     "wof:hierarchy":[
         {
@@ -73,7 +76,7 @@
         }
     ],
     "wof:id":421194241,
-    "wof:lastmodified":1566681795,
+    "wof:lastmodified":1582346797,
     "wof:name":"Bagacay",
     "wof:parent_id":1108697785,
     "wof:placetype":"locality",

--- a/data/421/194/529/421194529.geojson
+++ b/data/421/194/529/421194529.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009811,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2a8b578fbeb00592a4bca18a4a0dc85f",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":421194529,
-    "wof:lastmodified":1566681795,
+    "wof:lastmodified":1582346797,
     "wof:name":"Baras",
     "wof:parent_id":1108696899,
     "wof:placetype":"locality",

--- a/data/421/194/539/421194539.geojson
+++ b/data/421/194/539/421194539.geojson
@@ -259,6 +259,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009811,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"10e84dc7574624a849aa3a668e184591",
     "wof:hierarchy":[
         {
@@ -270,7 +273,7 @@
         }
     ],
     "wof:id":421194539,
-    "wof:lastmodified":1566681795,
+    "wof:lastmodified":1582346797,
     "wof:name":"Panglao",
     "wof:parent_id":890432909,
     "wof:placetype":"locality",

--- a/data/421/194/727/421194727.geojson
+++ b/data/421/194/727/421194727.geojson
@@ -133,6 +133,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009817,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"03d2270c18ddd2399b8bc78af84153b3",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
         }
     ],
     "wof:id":421194727,
-    "wof:lastmodified":1566681797,
+    "wof:lastmodified":1582346797,
     "wof:name":"Dingle",
     "wof:parent_id":1108698469,
     "wof:placetype":"locality",

--- a/data/421/194/751/421194751.geojson
+++ b/data/421/194/751/421194751.geojson
@@ -207,6 +207,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009818,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ff375f64560ae2019b63cbfee412e893",
     "wof:hierarchy":[
         {
@@ -218,7 +221,7 @@
         }
     ],
     "wof:id":421194751,
-    "wof:lastmodified":1566681795,
+    "wof:lastmodified":1582346797,
     "wof:name":"Bogo",
     "wof:parent_id":1108697033,
     "wof:placetype":"locality",

--- a/data/421/195/243/421195243.geojson
+++ b/data/421/195/243/421195243.geojson
@@ -379,6 +379,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009837,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"082f97aa3cd49a14cc90222c543004e4",
     "wof:hierarchy":[
         {
@@ -389,7 +392,7 @@
         }
     ],
     "wof:id":421195243,
-    "wof:lastmodified":1561778696,
+    "wof:lastmodified":1582346797,
     "wof:name":"Quezon City",
     "wof:parent_id":1159397243,
     "wof:placetype":"locality",

--- a/data/421/195/413/421195413.geojson
+++ b/data/421/195/413/421195413.geojson
@@ -282,6 +282,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009847,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"e1e3172082e59c410eafc3d3100017ea",
     "wof:hierarchy":[
         {
@@ -293,7 +296,7 @@
         }
     ],
     "wof:id":421195413,
-    "wof:lastmodified":1566681792,
+    "wof:lastmodified":1582346797,
     "wof:name":"Gingoog City",
     "wof:parent_id":1108697649,
     "wof:placetype":"locality",

--- a/data/421/196/943/421196943.geojson
+++ b/data/421/196/943/421196943.geojson
@@ -66,6 +66,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009898,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f2beb6abf4b37e42e1874a12682879f8",
     "wof:hierarchy":[
         {
@@ -77,7 +80,7 @@
         }
     ],
     "wof:id":421196943,
-    "wof:lastmodified":1566681844,
+    "wof:lastmodified":1582346798,
     "wof:name":"Concepcion",
     "wof:parent_id":1108699649,
     "wof:placetype":"locality",

--- a/data/421/197/511/421197511.geojson
+++ b/data/421/197/511/421197511.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009916,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d864806cce399921f19f185421487498",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421197511,
-    "wof:lastmodified":1566681848,
+    "wof:lastmodified":1582346798,
     "wof:name":"Jose Panganiban",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/198/977/421198977.geojson
+++ b/data/421/198/977/421198977.geojson
@@ -108,6 +108,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009973,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"375882204d351892c8ef30b804bc6713",
     "wof:hierarchy":[
         {
@@ -119,7 +122,7 @@
         }
     ],
     "wof:id":421198977,
-    "wof:lastmodified":1566681838,
+    "wof:lastmodified":1582346798,
     "wof:name":"Bobon",
     "wof:parent_id":1108697313,
     "wof:placetype":"locality",

--- a/data/421/198/981/421198981.geojson
+++ b/data/421/198/981/421198981.geojson
@@ -122,6 +122,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009973,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6713e88e2c792e5d512e44fc2bf506af",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421198981,
-    "wof:lastmodified":1566681841,
+    "wof:lastmodified":1582346798,
     "wof:name":"Binalonan",
     "wof:parent_id":1108699125,
     "wof:placetype":"locality",

--- a/data/421/198/985/421198985.geojson
+++ b/data/421/198/985/421198985.geojson
@@ -109,6 +109,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009973,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7ed4bff2cc52c51e93e15e35087badad",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":421198985,
-    "wof:lastmodified":1566681839,
+    "wof:lastmodified":1582346798,
     "wof:name":"Hinigaran",
     "wof:parent_id":1108697941,
     "wof:placetype":"locality",

--- a/data/421/199/439/421199439.geojson
+++ b/data/421/199/439/421199439.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459009989,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b325954b33d199e41e3a43f417f8e225",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421199439,
-    "wof:lastmodified":1566681851,
+    "wof:lastmodified":1582346799,
     "wof:name":"San Vicente",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/200/161/421200161.geojson
+++ b/data/421/200/161/421200161.geojson
@@ -61,6 +61,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459010013,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7841ba600f97eef5fc97f451254efb84",
     "wof:hierarchy":[
         {
@@ -72,7 +75,7 @@
         }
     ],
     "wof:id":421200161,
-    "wof:lastmodified":1566681854,
+    "wof:lastmodified":1582346799,
     "wof:name":"Lopez Jaena",
     "wof:parent_id":1108699073,
     "wof:placetype":"locality",

--- a/data/421/200/843/421200843.geojson
+++ b/data/421/200/843/421200843.geojson
@@ -265,6 +265,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459010043,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1df3840ee79dcf1848d711fc05a5e1c9",
     "wof:hierarchy":[
         {
@@ -276,7 +279,7 @@
         }
     ],
     "wof:id":421200843,
-    "wof:lastmodified":1566681855,
+    "wof:lastmodified":1582346799,
     "wof:name":"Bolinao",
     "wof:parent_id":1108697425,
     "wof:placetype":"locality",

--- a/data/421/200/845/421200845.geojson
+++ b/data/421/200/845/421200845.geojson
@@ -98,6 +98,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459010043,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a20940b141af9c7be78e0fe71c3d01a8",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
         }
     ],
     "wof:id":421200845,
-    "wof:lastmodified":1566681854,
+    "wof:lastmodified":1582346799,
     "wof:name":"Bontoc",
     "wof:parent_id":1108697893,
     "wof:placetype":"locality",

--- a/data/421/202/127/421202127.geojson
+++ b/data/421/202/127/421202127.geojson
@@ -215,6 +215,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459010106,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"697dabcb0b4729110ca9ff02d34404ed",
     "wof:hierarchy":[
         {
@@ -226,7 +229,7 @@
         }
     ],
     "wof:id":421202127,
-    "wof:lastmodified":1566681810,
+    "wof:lastmodified":1582346798,
     "wof:name":"Talisay",
     "wof:parent_id":1108699649,
     "wof:placetype":"locality",

--- a/data/421/202/567/421202567.geojson
+++ b/data/421/202/567/421202567.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459010122,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c40f8d7591c9e56ec8bc50ef03a17183",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":421202567,
-    "wof:lastmodified":1566681810,
+    "wof:lastmodified":1582346797,
     "wof:name":"Tuao",
     "wof:parent_id":1108699763,
     "wof:placetype":"locality",

--- a/data/421/203/173/421203173.geojson
+++ b/data/421/203/173/421203173.geojson
@@ -238,6 +238,7 @@
     "qs:woe_id":1200031,
     "src:geom":"quattroshapes",
     "src:geom_alt":[
+        "naturalearth",
         "quattroshapes_pg"
     ],
     "wd:wordcount":2352,
@@ -259,6 +260,10 @@
     },
     "wof:country":"PH",
     "wof:created":1459010142,
+    "wof:geom_alt":[
+        "naturalearth",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c6518be8cfb5329bd4732ae229961dbc",
     "wof:hierarchy":[
         {
@@ -270,7 +275,7 @@
         }
     ],
     "wof:id":421203173,
-    "wof:lastmodified":1566681808,
+    "wof:lastmodified":1582346797,
     "wof:name":"Laoag C",
     "wof:parent_id":890442475,
     "wof:placetype":"locality",

--- a/data/421/203/635/421203635.geojson
+++ b/data/421/203/635/421203635.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459010158,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f79694b4444e5123ca3ee8c01620ace4",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":421203635,
-    "wof:lastmodified":1566681808,
+    "wof:lastmodified":1582346797,
     "wof:name":"President Roxas",
     "wof:parent_id":1108698965,
     "wof:placetype":"locality",

--- a/data/421/203/715/421203715.geojson
+++ b/data/421/203/715/421203715.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459010161,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1d8f29730dae5a88d12f7cddcdef4dea",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":421203715,
-    "wof:lastmodified":1566681808,
+    "wof:lastmodified":1582346797,
     "wof:name":"Cervantes",
     "wof:parent_id":1108697349,
     "wof:placetype":"locality",

--- a/data/421/203/795/421203795.geojson
+++ b/data/421/203/795/421203795.geojson
@@ -229,6 +229,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459010164,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"daf65e51e4ede43ba8d6c03222c40c49",
     "wof:hierarchy":[
         {
@@ -240,7 +243,7 @@
         }
     ],
     "wof:id":421203795,
-    "wof:lastmodified":1566681808,
+    "wof:lastmodified":1582346797,
     "wof:name":"Calapan",
     "wof:parent_id":1108699579,
     "wof:placetype":"locality",

--- a/data/421/204/411/421204411.geojson
+++ b/data/421/204/411/421204411.geojson
@@ -82,6 +82,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459010185,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8030e7da821d77221d4ae6c2bede93d8",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":421204411,
-    "wof:lastmodified":1566681806,
+    "wof:lastmodified":1582346797,
     "wof:name":"Consuelo",
     "wof:parent_id":1108698607,
     "wof:placetype":"locality",

--- a/data/421/204/753/421204753.geojson
+++ b/data/421/204/753/421204753.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459010196,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"86b4f72b68d9df8b4827d414ae88c332",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":421204753,
-    "wof:lastmodified":1566681805,
+    "wof:lastmodified":1582346797,
     "wof:name":"Real",
     "wof:parent_id":1108699009,
     "wof:placetype":"locality",

--- a/data/421/205/331/421205331.geojson
+++ b/data/421/205/331/421205331.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"PH",
     "wof:created":1459010221,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a52809b6387ab05203910e514fe4d4ca",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":421205331,
-    "wof:lastmodified":1566681812,
+    "wof:lastmodified":1582346798,
     "wof:name":"Cardona",
     "wof:parent_id":1108697287,
     "wof:placetype":"locality",

--- a/data/856/759/29/85675929.geojson
+++ b/data/856/759/29/85675929.geojson
@@ -320,6 +320,9 @@
         "wd:id":"Q13893"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6345bd3248c6870bb9e853994ebe6ae6",
     "wof:hierarchy":[
         {
@@ -344,7 +347,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679697,
+    "wof:lastmodified":1582346761,
     "wof:name":"Tawi-Tawi",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/759/33/85675933.geojson
+++ b/data/856/759/33/85675933.geojson
@@ -349,6 +349,9 @@
         "wk:page":"Bohol"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cd9207a490431a3ca57498e08c6506c2",
     "wof:hierarchy":[
         {
@@ -373,7 +376,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679696,
+    "wof:lastmodified":1582346761,
     "wof:name":"Bohol",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/759/39/85675939.geojson
+++ b/data/856/759/39/85675939.geojson
@@ -343,6 +343,9 @@
         "wd:id":"Q13786"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"76dc2acadc142cbba9674220cbee2aa9",
     "wof:hierarchy":[
         {
@@ -367,7 +370,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679698,
+    "wof:lastmodified":1582346762,
     "wof:name":"Cebu",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/759/45/85675945.geojson
+++ b/data/856/759/45/85675945.geojson
@@ -321,6 +321,9 @@
         "wk:page":"Negros Oriental"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"00e00628089df4ff91ba5824fd047b00",
     "wof:hierarchy":[
         {
@@ -345,7 +348,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679697,
+    "wof:lastmodified":1582346762,
     "wof:name":"Negros Oriental",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/759/47/85675947.geojson
+++ b/data/856/759/47/85675947.geojson
@@ -336,6 +336,9 @@
         "wk:page":"Siquijor"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c711b802b4124e2a8a626e0ef5b0a214",
     "wof:hierarchy":[
         {
@@ -360,7 +363,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679700,
+    "wof:lastmodified":1582346763,
     "wof:name":"Siquijor",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/759/51/85675951.geojson
+++ b/data/856/759/51/85675951.geojson
@@ -322,6 +322,9 @@
         "wk:page":"Negros Occidental"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"326cc5eddcea55187458633973a8ce94",
     "wof:hierarchy":[
         {
@@ -346,7 +349,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679696,
+    "wof:lastmodified":1582346761,
     "wof:name":"Negros Occidental",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/759/55/85675955.geojson
+++ b/data/856/759/55/85675955.geojson
@@ -319,6 +319,9 @@
         "wk:page":"Basilan"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5c0f4d9c7035bbc5c9b684311766526d",
     "wof:hierarchy":[
         {
@@ -343,7 +346,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679699,
+    "wof:lastmodified":1582346762,
     "wof:name":"Basilan",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/759/61/85675961.geojson
+++ b/data/856/759/61/85675961.geojson
@@ -299,6 +299,9 @@
         "wk:page":"Zamboanga del Norte"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5eabd27d71989d36548361391f824efd",
     "wof:hierarchy":[
         {
@@ -323,7 +326,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679695,
+    "wof:lastmodified":1582346761,
     "wof:name":"Zamboanga del Norte",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/759/63/85675963.geojson
+++ b/data/856/759/63/85675963.geojson
@@ -308,6 +308,9 @@
         "wd:id":"Q13902"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"131cbb9470d139fc179e52fbecb42946",
     "wof:hierarchy":[
         {
@@ -332,7 +335,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679699,
+    "wof:lastmodified":1582346762,
     "wof:name":"Zamboanga Sibugay",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/759/67/85675967.geojson
+++ b/data/856/759/67/85675967.geojson
@@ -306,6 +306,9 @@
         "wk:page":"Zamboanga del Sur"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"24f8eedfb84863cd80bd93cf296ade4c",
     "wof:hierarchy":[
         {
@@ -330,7 +333,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679696,
+    "wof:lastmodified":1582346761,
     "wof:name":"Zamboanga del Sur",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/759/71/85675971.geojson
+++ b/data/856/759/71/85675971.geojson
@@ -308,6 +308,9 @@
         "wk:page":"Misamis Occidental"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3587b6059af0c1183bc10a17e5d1f03b",
     "wof:hierarchy":[
         {
@@ -332,7 +335,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679699,
+    "wof:lastmodified":1582346762,
     "wof:name":"Misamis Occidental",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/759/75/85675975.geojson
+++ b/data/856/759/75/85675975.geojson
@@ -321,6 +321,9 @@
         "wk:page":"Sulu"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"17798ada56b379c36eba6de8bdb94f6f",
     "wof:hierarchy":[
         {
@@ -345,7 +348,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679698,
+    "wof:lastmodified":1582346762,
     "wof:name":"Sulu",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/759/81/85675981.geojson
+++ b/data/856/759/81/85675981.geojson
@@ -308,6 +308,9 @@
         "wk:page":"Aklan"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fde64d6025d7993de3793c7963f0e779",
     "wof:hierarchy":[
         {
@@ -332,7 +335,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679698,
+    "wof:lastmodified":1582346762,
     "wof:name":"Aklan",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/759/85/85675985.geojson
+++ b/data/856/759/85/85675985.geojson
@@ -299,6 +299,9 @@
         "wk:page":"Antique (province)"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"27f856390ed0a2fd97e30c5149033b72",
     "wof:hierarchy":[
         {
@@ -323,7 +326,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679699,
+    "wof:lastmodified":1582346762,
     "wof:name":"Antique",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/759/89/85675989.geojson
+++ b/data/856/759/89/85675989.geojson
@@ -309,6 +309,9 @@
         "wk:page":"Capiz"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b44c6d2fb3ecc4369852bd422596a2cd",
     "wof:hierarchy":[
         {
@@ -333,7 +336,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679697,
+    "wof:lastmodified":1582346761,
     "wof:name":"Capiz",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/759/93/85675993.geojson
+++ b/data/856/759/93/85675993.geojson
@@ -325,6 +325,9 @@
         "wk:page":"Iloilo"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2e63507af86433245f1596e31959f24a",
     "wof:hierarchy":[
         {
@@ -349,7 +352,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679696,
+    "wof:lastmodified":1582346761,
     "wof:name":"Iloilo",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/759/99/85675999.geojson
+++ b/data/856/759/99/85675999.geojson
@@ -317,6 +317,9 @@
         "wd:id":"Q13810"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"35f728ce8b37037ffde55605b22bb38d",
     "wof:hierarchy":[
         {
@@ -341,7 +344,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679699,
+    "wof:lastmodified":1582346762,
     "wof:name":"Guimaras",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/760/03/85676003.geojson
+++ b/data/856/760/03/85676003.geojson
@@ -352,6 +352,9 @@
         "wd:id":"Q13869"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e8abd3eb6d069097b0e40f4809676182",
     "wof:hierarchy":[
         {
@@ -376,7 +379,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679686,
+    "wof:lastmodified":1582346756,
     "wof:name":"Palawan",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/760/07/85676007.geojson
+++ b/data/856/760/07/85676007.geojson
@@ -312,6 +312,9 @@
         "wk:page":"Romblon"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"80527feb932770f2ac885f6808a78df8",
     "wof:hierarchy":[
         {
@@ -336,7 +339,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679688,
+    "wof:lastmodified":1582346757,
     "wof:name":"Romblon",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/760/11/85676011.geojson
+++ b/data/856/760/11/85676011.geojson
@@ -314,6 +314,9 @@
         "wd:id":"Q13726"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2a716d49b19dc8ac3755f98a745e5c35",
     "wof:hierarchy":[
         {
@@ -338,7 +341,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679687,
+    "wof:lastmodified":1582346756,
     "wof:name":"Albay",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/760/17/85676017.geojson
+++ b/data/856/760/17/85676017.geojson
@@ -317,6 +317,9 @@
         "wd:id":"Q13763"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8311128ecd307d9ee9cab22349b967c0",
     "wof:hierarchy":[
         {
@@ -341,7 +344,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679688,
+    "wof:lastmodified":1582346757,
     "wof:name":"Camarines Norte",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/760/21/85676021.geojson
+++ b/data/856/760/21/85676021.geojson
@@ -299,6 +299,9 @@
         "wd:id":"Q13767"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d569c72c8568f14ac9032ff7e55389c7",
     "wof:hierarchy":[
         {
@@ -323,7 +326,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679688,
+    "wof:lastmodified":1582346757,
     "wof:name":"Camarines Sur",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/760/25/85676025.geojson
+++ b/data/856/760/25/85676025.geojson
@@ -320,6 +320,9 @@
         "wd:id":"Q13778"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6044629d4326527f657bf4431087edd5",
     "wof:hierarchy":[
         {
@@ -344,7 +347,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679690,
+    "wof:lastmodified":1582346758,
     "wof:name":"Catanduanes",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/760/29/85676029.geojson
+++ b/data/856/760/29/85676029.geojson
@@ -317,6 +317,9 @@
         "wd:id":"Q13847"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ff7ff7ae8161bec05f83ed1fb2a4a7bd",
     "wof:hierarchy":[
         {
@@ -341,7 +344,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679687,
+    "wof:lastmodified":1582346757,
     "wof:name":"Masbate",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/760/35/85676035.geojson
+++ b/data/856/760/35/85676035.geojson
@@ -317,6 +317,9 @@
         "wd:id":"Q13881"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5e42230b2eb060e8e7356986f07bef4e",
     "wof:hierarchy":[
         {
@@ -341,7 +344,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679686,
+    "wof:lastmodified":1582346756,
     "wof:name":"Sorsogon",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/760/39/85676039.geojson
+++ b/data/856/760/39/85676039.geojson
@@ -296,6 +296,9 @@
         "wk:page":"Abra (province)"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ce2749d5e3a1be0e672039e64b594660",
     "wof:hierarchy":[
         {
@@ -320,7 +323,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679689,
+    "wof:lastmodified":1582346757,
     "wof:name":"Abra",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/760/43/85676043.geojson
+++ b/data/856/760/43/85676043.geojson
@@ -318,6 +318,9 @@
         "wk:page":"Batanes"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"72f37898f22da7982c6168e301fe8903",
     "wof:hierarchy":[
         {
@@ -342,7 +345,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679688,
+    "wof:lastmodified":1582346757,
     "wof:name":"Batanes",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/760/47/85676047.geojson
+++ b/data/856/760/47/85676047.geojson
@@ -310,6 +310,9 @@
         "wk:page":"Cagayan"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"63b9a919560e480154240a80a355dac7",
     "wof:hierarchy":[
         {
@@ -334,7 +337,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679690,
+    "wof:lastmodified":1582346758,
     "wof:name":"Cagayan",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/760/53/85676053.geojson
+++ b/data/856/760/53/85676053.geojson
@@ -309,6 +309,9 @@
         "wk:page":"Apayao"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c17edbd4cfb9ad87da7c80a44458ae3a",
     "wof:hierarchy":[
         {
@@ -333,7 +336,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679689,
+    "wof:lastmodified":1582346757,
     "wof:name":"Apayao",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/760/57/85676057.geojson
+++ b/data/856/760/57/85676057.geojson
@@ -326,6 +326,9 @@
         "wd:id":"Q13813"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"de168d4a3b4164f12b569969737ce81f",
     "wof:hierarchy":[
         {
@@ -350,7 +353,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679685,
+    "wof:lastmodified":1582346756,
     "wof:name":"Ilocos Norte",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/760/61/85676061.geojson
+++ b/data/856/760/61/85676061.geojson
@@ -314,6 +314,9 @@
         "wd:id":"Q12741"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6a4915184c7791ae3bc68a2bfacc3bc3",
     "wof:hierarchy":[
         {
@@ -338,7 +341,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679685,
+    "wof:lastmodified":1582346755,
     "wof:name":"Ilocos Sur",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/760/65/85676065.geojson
+++ b/data/856/760/65/85676065.geojson
@@ -314,6 +314,9 @@
         "wk:page":"Aurora (province)"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ae66c15b63ae9f7cdcbfad52172e6be1",
     "wof:hierarchy":[
         {
@@ -338,7 +341,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679689,
+    "wof:lastmodified":1582346757,
     "wof:name":"Aurora",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/760/73/85676073.geojson
+++ b/data/856/760/73/85676073.geojson
@@ -277,6 +277,9 @@
         "wk:page":"Isabela (province)"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"03a1ef3c56d78af80efcad97e8c96e22",
     "wof:hierarchy":[
         {
@@ -301,7 +304,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679687,
+    "wof:lastmodified":1582346757,
     "wof:name":"Isabela",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/760/77/85676077.geojson
+++ b/data/856/760/77/85676077.geojson
@@ -309,6 +309,9 @@
         "wk:page":"Ifugao"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"331adcef2f2c9bb0ce5abc62a99c1d7e",
     "wof:hierarchy":[
         {
@@ -333,7 +336,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679690,
+    "wof:lastmodified":1582346758,
     "wof:name":"Ifugao",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/760/79/85676079.geojson
+++ b/data/856/760/79/85676079.geojson
@@ -331,6 +331,9 @@
         "wk:page":"Mountain Province"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"de29952213dbe579aa545b456ee7f8a2",
     "wof:hierarchy":[
         {
@@ -355,7 +358,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679689,
+    "wof:lastmodified":1582346758,
     "wof:name":"Mountain Province",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/760/83/85676083.geojson
+++ b/data/856/760/83/85676083.geojson
@@ -330,6 +330,9 @@
         "wk:page":"Nueva Vizcaya"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"23a497cb43bc3c0803253188891b8b1e",
     "wof:hierarchy":[
         {
@@ -354,7 +357,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679690,
+    "wof:lastmodified":1582346758,
     "wof:name":"Nueva Vizcaya",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/760/89/85676089.geojson
+++ b/data/856/760/89/85676089.geojson
@@ -306,6 +306,9 @@
         "wk:page":"Quirino"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a5fd6da2292882a07a5ba327d2d9d2a8",
     "wof:hierarchy":[
         {
@@ -330,7 +333,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679687,
+    "wof:lastmodified":1582346757,
     "wof:name":"Quirino",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/760/93/85676093.geojson
+++ b/data/856/760/93/85676093.geojson
@@ -308,6 +308,9 @@
         "wk:page":"Bataan"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"51dcf8c41c70f42b23d016c3fdfe440c",
     "wof:hierarchy":[
         {
@@ -332,7 +335,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679687,
+    "wof:lastmodified":1582346756,
     "wof:name":"Bataan",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/760/97/85676097.geojson
+++ b/data/856/760/97/85676097.geojson
@@ -321,6 +321,9 @@
         "wk:page":"Tarlac"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"505a8a74fe33203a17caf69da368f444",
     "wof:hierarchy":[
         {
@@ -345,7 +348,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679689,
+    "wof:lastmodified":1582346758,
     "wof:name":"Tarlac",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/761/01/85676101.geojson
+++ b/data/856/761/01/85676101.geojson
@@ -321,6 +321,9 @@
         "wk:page":"Nueva Ecija"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5d2ed916d7cd3d4150dcb307ceec0b97",
     "wof:hierarchy":[
         {
@@ -345,7 +348,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679694,
+    "wof:lastmodified":1582346760,
     "wof:name":"Nueva Ecija",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/761/07/85676107.geojson
+++ b/data/856/761/07/85676107.geojson
@@ -327,6 +327,9 @@
         "wk:page":"Pampanga"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"30da6f9e75dbcfc50a3fa2e536b50134",
     "wof:hierarchy":[
         {
@@ -351,7 +354,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679693,
+    "wof:lastmodified":1582346759,
     "wof:name":"Pampanga",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/761/11/85676111.geojson
+++ b/data/856/761/11/85676111.geojson
@@ -302,6 +302,9 @@
     },
     "wof:concordances:hasc:id":"",
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cb132d209812faaf2817b051d8820d1a",
     "wof:hierarchy":[
         {
@@ -326,7 +329,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679692,
+    "wof:lastmodified":1582346759,
     "wof:name":"Banguet",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/761/13/85676113.geojson
+++ b/data/856/761/13/85676113.geojson
@@ -321,6 +321,9 @@
         "wk:page":"Zambales"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4a241180ba7ae58ab74b80d1dcd56514",
     "wof:hierarchy":[
         {
@@ -345,7 +348,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679695,
+    "wof:lastmodified":1582346760,
     "wof:name":"Zambales",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/761/19/85676119.geojson
+++ b/data/856/761/19/85676119.geojson
@@ -305,6 +305,9 @@
         "wd:id":"Q13829"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c8d12fe42545f7c72ec5333d5dde0617",
     "wof:hierarchy":[
         {
@@ -329,7 +332,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679693,
+    "wof:lastmodified":1582346759,
     "wof:name":"La Union",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/761/23/85676123.geojson
+++ b/data/856/761/23/85676123.geojson
@@ -307,6 +307,9 @@
         "wd:id":"Q13871"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3359bfb22a1e51cf679429dad5efc229",
     "wof:hierarchy":[
         {
@@ -331,7 +334,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679695,
+    "wof:lastmodified":1582346760,
     "wof:name":"Pangasinan",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/761/27/85676127.geojson
+++ b/data/856/761/27/85676127.geojson
@@ -330,6 +330,9 @@
         "wk:page":"Cavite"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4a1be80a11947bfccc37e829cb9c650f",
     "wof:hierarchy":[
         {
@@ -354,7 +357,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679692,
+    "wof:lastmodified":1582346759,
     "wof:name":"Cavite",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/761/31/85676131.geojson
+++ b/data/856/761/31/85676131.geojson
@@ -321,6 +321,9 @@
         "wk:page":"Batangas"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1e00bdea06a384f51ea7fd7d08ab2be6",
     "wof:hierarchy":[
         {
@@ -345,7 +348,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679693,
+    "wof:lastmodified":1582346759,
     "wof:name":"Batangas",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/761/35/85676135.geojson
+++ b/data/856/761/35/85676135.geojson
@@ -324,6 +324,9 @@
         "wk:page":"Bulacan"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ddb129548b49923c06c98b28235f637e",
     "wof:hierarchy":[
         {
@@ -348,7 +351,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679691,
+    "wof:lastmodified":1582346759,
     "wof:name":"Bulacan",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/761/41/85676141.geojson
+++ b/data/856/761/41/85676141.geojson
@@ -316,6 +316,9 @@
         "wk:page":"Laguna (province)"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0a2660ad0ac077d28e15285b67724906",
     "wof:hierarchy":[
         {
@@ -340,7 +343,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679695,
+    "wof:lastmodified":1582346760,
     "wof:name":"Laguna",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/761/45/85676145.geojson
+++ b/data/856/761/45/85676145.geojson
@@ -312,6 +312,9 @@
         "wk:page":"Rizal"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3470f66bf754b2a7f56ebba5020a40ae",
     "wof:hierarchy":[
         {
@@ -336,7 +339,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679692,
+    "wof:lastmodified":1582346759,
     "wof:name":"Rizal",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/761/49/85676149.geojson
+++ b/data/856/761/49/85676149.geojson
@@ -331,6 +331,9 @@
         "wk:page":"Marinduque"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5dc179691119e8e6cc3f6fbac28942fa",
     "wof:hierarchy":[
         {
@@ -355,7 +358,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679695,
+    "wof:lastmodified":1582346760,
     "wof:name":"Marinduque",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/761/53/85676153.geojson
+++ b/data/856/761/53/85676153.geojson
@@ -307,6 +307,9 @@
         "wk:page":"Occidental Mindoro"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"07bc76552b8dae4725a00f9ca0302f10",
     "wof:hierarchy":[
         {
@@ -331,7 +334,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679694,
+    "wof:lastmodified":1582346760,
     "wof:name":"Mindoro Occidental",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/761/59/85676159.geojson
+++ b/data/856/761/59/85676159.geojson
@@ -300,6 +300,9 @@
         "wk:page":"Oriental Mindoro"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"67e67cb0c3be6b7374c3badba403ca79",
     "wof:hierarchy":[
         {
@@ -324,7 +327,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679691,
+    "wof:lastmodified":1582346758,
     "wof:name":"Mindoro Oriental",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/761/61/85676161.geojson
+++ b/data/856/761/61/85676161.geojson
@@ -305,6 +305,9 @@
         "wk:page":"Quezon"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b295ff91a1ce1671465edb1af12a1e0e",
     "wof:hierarchy":[
         {
@@ -329,7 +332,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679690,
+    "wof:lastmodified":1582346758,
     "wof:name":"Quezon",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/761/65/85676165.geojson
+++ b/data/856/761/65/85676165.geojson
@@ -300,6 +300,9 @@
         "wk:page":"Lanao del Norte"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"82042233f652842e98368e20b639a616",
     "wof:hierarchy":[
         {
@@ -324,7 +327,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679694,
+    "wof:lastmodified":1582346759,
     "wof:name":"Lanao del Norte",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/761/69/85676169.geojson
+++ b/data/856/761/69/85676169.geojson
@@ -312,6 +312,9 @@
         "wk:page":"Lanao del Sur"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"56af12bd14fcb0ff7b896cfe40ec9708",
     "wof:hierarchy":[
         {
@@ -336,7 +339,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679691,
+    "wof:lastmodified":1582346759,
     "wof:name":"Lanao del Sur",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/761/73/85676173.geojson
+++ b/data/856/761/73/85676173.geojson
@@ -243,6 +243,9 @@
         "wk:page":"Maguindanao"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"34270a013b938ca703548a6c7bb1c0ef",
     "wof:hierarchy":[
         {
@@ -267,7 +270,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679692,
+    "wof:lastmodified":1582346759,
     "wof:name":"Maguindanao",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/761/79/85676179.geojson
+++ b/data/856/761/79/85676179.geojson
@@ -312,6 +312,9 @@
         "wk:page":"Cotabato"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"68b3cc9fb68d2a10bddb0544c8fdf053",
     "wof:hierarchy":[
         {
@@ -336,7 +339,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679694,
+    "wof:lastmodified":1582346760,
     "wof:name":"North Cotabato",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/761/83/85676183.geojson
+++ b/data/856/761/83/85676183.geojson
@@ -296,6 +296,9 @@
         "wk:page":"Sultan Kudarat"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a901d0c54d855a0cb0c250740fdeecc8",
     "wof:hierarchy":[
         {
@@ -320,7 +323,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679695,
+    "wof:lastmodified":1582346760,
     "wof:name":"Sultan Kudarat",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/761/87/85676187.geojson
+++ b/data/856/761/87/85676187.geojson
@@ -329,6 +329,9 @@
         "wd:id":"Q13751"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d6e473690955919602f118a1db6537f8",
     "wof:hierarchy":[
         {
@@ -353,7 +356,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679692,
+    "wof:lastmodified":1582346759,
     "wof:name":"Biliran",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/761/91/85676191.geojson
+++ b/data/856/761/91/85676191.geojson
@@ -322,6 +322,9 @@
         "wk:page":"Eastern Samar"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e98bbf8129eec41479678928c47489ce",
     "wof:hierarchy":[
         {
@@ -346,7 +349,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679693,
+    "wof:lastmodified":1582346759,
     "wof:name":"Eastern Samar",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/761/97/85676197.geojson
+++ b/data/856/761/97/85676197.geojson
@@ -322,6 +322,9 @@
         "wk:page":"Leyte (province)"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cc465dac0d5520c492254fe439739b10",
     "wof:hierarchy":[
         {
@@ -346,7 +349,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679694,
+    "wof:lastmodified":1582346760,
     "wof:name":"Leyte",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/762/01/85676201.geojson
+++ b/data/856/762/01/85676201.geojson
@@ -391,6 +391,9 @@
         "wk:page":"Samar"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e8a94d9d2e0a5603ba6f7932639f0404",
     "wof:hierarchy":[
         {
@@ -415,7 +418,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679674,
+    "wof:lastmodified":1582346747,
     "wof:name":"Samar",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/762/03/85676203.geojson
+++ b/data/856/762/03/85676203.geojson
@@ -326,6 +326,9 @@
         "wk:page":"Southern Leyte"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a79d4efde9513a2c99ff938c7ccc10e1",
     "wof:hierarchy":[
         {
@@ -350,7 +353,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679671,
+    "wof:lastmodified":1582346746,
     "wof:name":"Southern Leyte",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/762/09/85676209.geojson
+++ b/data/856/762/09/85676209.geojson
@@ -332,6 +332,9 @@
         "wk:page":"Northern Samar"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"59ce2746dd8ed465899043b5bc41e71e",
     "wof:hierarchy":[
         {
@@ -356,7 +359,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679672,
+    "wof:lastmodified":1582346746,
     "wof:name":"Northern Samar",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/762/13/85676213.geojson
+++ b/data/856/762/13/85676213.geojson
@@ -295,6 +295,9 @@
         "wk:page":"Agusan del Norte"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a59ec5a0638d0acbd05609ae13b7f36e",
     "wof:hierarchy":[
         {
@@ -319,7 +322,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679675,
+    "wof:lastmodified":1582346747,
     "wof:name":"Agusan del Norte",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/762/17/85676217.geojson
+++ b/data/856/762/17/85676217.geojson
@@ -306,6 +306,9 @@
         "wk:page":"Agusan del Sur"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3ed8bb9ddeeb96e8ec9b14259f5d0b51",
     "wof:hierarchy":[
         {
@@ -330,7 +333,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679672,
+    "wof:lastmodified":1582346746,
     "wof:name":"Agusan del Sur",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/762/21/85676221.geojson
+++ b/data/856/762/21/85676221.geojson
@@ -312,6 +312,9 @@
         "wk:page":"Bukidnon"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ebfd1717cd65d7c67626be3fd399f707",
     "wof:hierarchy":[
         {
@@ -336,7 +339,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679672,
+    "wof:lastmodified":1582346746,
     "wof:name":"Bukidnon",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/762/25/85676225.geojson
+++ b/data/856/762/25/85676225.geojson
@@ -327,6 +327,9 @@
         "wk:page":"Camiguin"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e68230606423a7ca481b9d8d13fac558",
     "wof:hierarchy":[
         {
@@ -351,7 +354,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679675,
+    "wof:lastmodified":1582346747,
     "wof:name":"Camiguin",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/762/31/85676231.geojson
+++ b/data/856/762/31/85676231.geojson
@@ -308,6 +308,9 @@
         "wd:id":"Q13792"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"546c4c5643f18f7c067e0f685754dfe5",
     "wof:hierarchy":[
         {
@@ -332,7 +335,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679673,
+    "wof:lastmodified":1582346746,
     "wof:name":"Davao del Norte",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/762/35/85676235.geojson
+++ b/data/856/762/35/85676235.geojson
@@ -311,6 +311,9 @@
         "wd:id":"Q13789"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cc6af1b4f1d38d24f040a988cef1c3eb",
     "wof:hierarchy":[
         {
@@ -335,7 +338,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679671,
+    "wof:lastmodified":1582346746,
     "wof:name":"Compostela Valley",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/762/39/85676239.geojson
+++ b/data/856/762/39/85676239.geojson
@@ -288,6 +288,9 @@
         "wk:page":"Surigao del Norte"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a8152f41c0ac9e2fade8aa8a25d28132",
     "wof:hierarchy":[
         {
@@ -312,7 +315,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679674,
+    "wof:lastmodified":1582346747,
     "wof:name":"Surigao del Norte",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/762/43/85676243.geojson
+++ b/data/856/762/43/85676243.geojson
@@ -300,6 +300,9 @@
         "wk:page":"Surigao del Sur"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1643663edb10ae3325de2ef172b151a7",
     "wof:hierarchy":[
         {
@@ -324,7 +327,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679672,
+    "wof:lastmodified":1582346746,
     "wof:name":"Surigao del Sur",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/762/49/85676249.geojson
+++ b/data/856/762/49/85676249.geojson
@@ -306,6 +306,9 @@
         "wk:page":"Misamis Oriental"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"11842cb347d9ff1705ce512121300afe",
     "wof:hierarchy":[
         {
@@ -330,7 +333,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679675,
+    "wof:lastmodified":1582346747,
     "wof:name":"Misamis Oriental",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/762/53/85676253.geojson
+++ b/data/856/762/53/85676253.geojson
@@ -290,6 +290,9 @@
         "wd:id":"Q13794"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e475ff46138d6170abebabdb465a9329",
     "wof:hierarchy":[
         {
@@ -314,7 +317,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679673,
+    "wof:lastmodified":1582346746,
     "wof:name":"Davao del Sur",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/762/55/85676255.geojson
+++ b/data/856/762/55/85676255.geojson
@@ -308,6 +308,9 @@
         "wd:id":"Q13806"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9925f9f9a26aa9d5ee1770f41287066c",
     "wof:hierarchy":[
         {
@@ -332,7 +335,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679674,
+    "wof:lastmodified":1582346747,
     "wof:name":"Davao Oriental",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/762/59/85676259.geojson
+++ b/data/856/762/59/85676259.geojson
@@ -312,6 +312,9 @@
         "wk:page":"Sarangani"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"89ea6a60f9c976334a751ebbee7cead3",
     "wof:hierarchy":[
         {
@@ -336,7 +339,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679671,
+    "wof:lastmodified":1582346745,
     "wof:name":"Sarangani",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/762/63/85676263.geojson
+++ b/data/856/762/63/85676263.geojson
@@ -236,6 +236,9 @@
         "wk:page":"South Cotabato"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"de7d667c17be0973c14694e4f8b7696f",
     "wof:hierarchy":[
         {
@@ -260,7 +263,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679675,
+    "wof:lastmodified":1582346747,
     "wof:name":"South Cotabato",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/762/69/85676269.geojson
+++ b/data/856/762/69/85676269.geojson
@@ -297,6 +297,9 @@
         "wk:page":"Kalinga (province)"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f9ac4992eab9fe5a08ad036624f88b1e",
     "wof:hierarchy":[
         {
@@ -321,7 +324,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679672,
+    "wof:lastmodified":1582346746,
     "wof:name":"Kalinga",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/762/77/85676277.geojson
+++ b/data/856/762/77/85676277.geojson
@@ -314,6 +314,9 @@
     },
     "wof:concordances:hasc:id":"",
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e2ec947762592a5a994878341300d3b7",
     "wof:hierarchy":[
         {
@@ -338,7 +341,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679675,
+    "wof:lastmodified":1582346747,
     "wof:name":"Isabela",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/762/81/85676281.geojson
+++ b/data/856/762/81/85676281.geojson
@@ -340,6 +340,9 @@
     },
     "wof:concordances:hasc:id":"",
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"48f31cd6bb06f2435f7a6a2ae2c0e4b8",
     "wof:hierarchy":[
         {
@@ -364,7 +367,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679672,
+    "wof:lastmodified":1582346746,
     "wof:name":"Cebu",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/762/87/85676287.geojson
+++ b/data/856/762/87/85676287.geojson
@@ -243,6 +243,9 @@
     },
     "wof:concordances:hasc:id":"",
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"328e9bc179f76479fb35730a35d364fd",
     "wof:hierarchy":[
         {
@@ -267,7 +270,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679672,
+    "wof:lastmodified":1582346746,
     "wof:name":"Mandaue",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/762/91/85676291.geojson
+++ b/data/856/762/91/85676291.geojson
@@ -338,6 +338,9 @@
         "wd:id":"Q13669"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"095363670328535ee9bd14bbf5c90081",
     "wof:hierarchy":[
         {
@@ -362,7 +365,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679673,
+    "wof:lastmodified":1582346746,
     "wof:name":"Lapu-Lapu",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/762/95/85676295.geojson
+++ b/data/856/762/95/85676295.geojson
@@ -312,6 +312,9 @@
     },
     "wof:concordances:hasc:id":"",
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a1616d47e09fb06cb5700fc37fc6bcb1",
     "wof:hierarchy":[
         {
@@ -336,7 +339,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679671,
+    "wof:lastmodified":1582346745,
     "wof:name":"Bacolod",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/762/99/85676299.geojson
+++ b/data/856/762/99/85676299.geojson
@@ -277,6 +277,9 @@
     },
     "wof:concordances:hasc:id":"",
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"46deaf9b11f5f6e68e6797e459d7cbda",
     "wof:hierarchy":[
         {
@@ -301,7 +304,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679674,
+    "wof:lastmodified":1582346747,
     "wof:name":"Iloilo",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/763/05/85676305.geojson
+++ b/data/856/763/05/85676305.geojson
@@ -209,6 +209,9 @@
         "wk:page":"Maguindanao"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fe18b8865aa29c1764b7967702ae8386",
     "wof:hierarchy":[
         {
@@ -233,7 +236,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679668,
+    "wof:lastmodified":1582346744,
     "wof:name":"Cotabato",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/763/09/85676309.geojson
+++ b/data/856/763/09/85676309.geojson
@@ -173,6 +173,9 @@
         "wd:id":"Q407504"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"94c827ede51b7c273ce9900f1bf740e1",
     "wof:hierarchy":[
         {
@@ -197,7 +200,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679669,
+    "wof:lastmodified":1582346745,
     "wof:name":"Davao",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/763/13/85676313.geojson
+++ b/data/856/763/13/85676313.geojson
@@ -217,6 +217,9 @@
     },
     "wof:concordances:hasc:id":"",
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"70e0d0218372660a44bf2a1ac3d2ec41",
     "wof:hierarchy":[
         {
@@ -241,7 +244,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679670,
+    "wof:lastmodified":1582346745,
     "wof:name":"General Santos",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/763/17/85676317.geojson
+++ b/data/856/763/17/85676317.geojson
@@ -167,6 +167,9 @@
     },
     "wof:concordances:hasc:id":"",
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"467710d8fd4e157f38da570112b3c540",
     "wof:hierarchy":[
         {
@@ -191,7 +194,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679669,
+    "wof:lastmodified":1582346744,
     "wof:name":"Iligan",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/763/23/85676323.geojson
+++ b/data/856/763/23/85676323.geojson
@@ -167,6 +167,9 @@
     },
     "wof:concordances:hasc:id":"",
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"43bc565f2eec42e5322aa6782259aeb6",
     "wof:hierarchy":[
         {
@@ -191,7 +194,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679670,
+    "wof:lastmodified":1582346745,
     "wof:name":"Cagayan de Oro",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/763/27/85676327.geojson
+++ b/data/856/763/27/85676327.geojson
@@ -293,6 +293,9 @@
     },
     "wof:concordances:hasc:id":"",
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8f150c3b1e99288c2b72648e55242725",
     "wof:hierarchy":[
         {
@@ -317,7 +320,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679668,
+    "wof:lastmodified":1582346744,
     "wof:name":"Butuan",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/763/31/85676331.geojson
+++ b/data/856/763/31/85676331.geojson
@@ -179,6 +179,9 @@
     },
     "wof:concordances:hasc:id":"",
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d84f0c565464f49d1f4044d6d6f8f634",
     "wof:hierarchy":[
         {
@@ -203,7 +206,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679669,
+    "wof:lastmodified":1582346745,
     "wof:name":"Puerto Princesa",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/763/35/85676335.geojson
+++ b/data/856/763/35/85676335.geojson
@@ -176,6 +176,9 @@
     },
     "wof:concordances:hasc:id":"",
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f8e1271caab9a6e6327339a325a00d70",
     "wof:hierarchy":[
         {
@@ -200,7 +203,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679668,
+    "wof:lastmodified":1582346744,
     "wof:name":"Ormuc",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/763/41/85676341.geojson
+++ b/data/856/763/41/85676341.geojson
@@ -374,6 +374,9 @@
     },
     "wof:concordances:hasc:id":"",
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"37cb4777ca477967488d25832e13ecf2",
     "wof:hierarchy":[
         {
@@ -398,7 +401,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679669,
+    "wof:lastmodified":1582346745,
     "wof:name":"Tacloban",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/763/45/85676345.geojson
+++ b/data/856/763/45/85676345.geojson
@@ -362,6 +362,9 @@
     },
     "wof:concordances:hasc:id":"",
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f4bf2f79f79e8fa1319838c77bfff5af",
     "wof:hierarchy":[
         {
@@ -386,7 +389,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679669,
+    "wof:lastmodified":1582346744,
     "wof:name":"Naga",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/763/49/85676349.geojson
+++ b/data/856/763/49/85676349.geojson
@@ -638,6 +638,9 @@
     },
     "wof:concordances:hasc:id":"",
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ab9d4a47e7d703cdc2b68e5a9745d5e3",
     "wof:hierarchy":[
         {
@@ -662,7 +665,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679670,
+    "wof:lastmodified":1582346745,
     "wof:name":"Santiago",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/763/51/85676351.geojson
+++ b/data/856/763/51/85676351.geojson
@@ -194,6 +194,9 @@
     },
     "wof:concordances:hasc:id":"",
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3c11b3a2124c01f9080da7230221c3bb",
     "wof:hierarchy":[
         {
@@ -218,7 +221,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679668,
+    "wof:lastmodified":1582346744,
     "wof:name":"Angeles",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/763/59/85676359.geojson
+++ b/data/856/763/59/85676359.geojson
@@ -311,6 +311,9 @@
         "wd:id":"Q1822"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"78eb44ec0c725141c287a6fc2d504e91",
     "wof:hierarchy":[
         {
@@ -335,7 +338,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679668,
+    "wof:lastmodified":1582346744,
     "wof:name":"Benguet",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/763/61/85676361.geojson
+++ b/data/856/763/61/85676361.geojson
@@ -239,6 +239,9 @@
     },
     "wof:concordances:hasc:id":"",
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c2d1fd0652e00128d3624bb563f413c6",
     "wof:hierarchy":[
         {
@@ -263,7 +266,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679668,
+    "wof:lastmodified":1582346744,
     "wof:name":"Olongapo",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/763/65/85676365.geojson
+++ b/data/856/763/65/85676365.geojson
@@ -266,6 +266,9 @@
     },
     "wof:concordances:hasc:id":"",
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5e3b0057ed76fec9f77fed170969a374",
     "wof:hierarchy":[
         {
@@ -290,7 +293,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679669,
+    "wof:lastmodified":1582346745,
     "wof:name":"Dagupan",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/763/69/85676369.geojson
+++ b/data/856/763/69/85676369.geojson
@@ -262,6 +262,9 @@
     },
     "wof:concordances:hasc:id":"",
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"73f7a99de95b1cba0bcbc31174419a4a",
     "wof:hierarchy":[
         {
@@ -286,7 +289,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1561778476,
+    "wof:lastmodified":1582346744,
     "wof:name":"Mandaluyong City",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/763/75/85676375.geojson
+++ b/data/856/763/75/85676375.geojson
@@ -201,6 +201,9 @@
         "wd:id":"Q13580"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"81cd8b2137d55dc8fde0710feba5dcf5",
     "wof:hierarchy":[
         {
@@ -225,7 +228,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1561778476,
+    "wof:lastmodified":1582346745,
     "wof:name":"Metro Manila",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/763/79/85676379.geojson
+++ b/data/856/763/79/85676379.geojson
@@ -280,6 +280,9 @@
     },
     "wof:concordances:hasc:id":"",
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"affadb5a9b366dd9a550f65c3cd39070",
     "wof:hierarchy":[
         {
@@ -304,7 +307,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1561778476,
+    "wof:lastmodified":1582346745,
     "wof:name":"Navotas",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/763/83/85676383.geojson
+++ b/data/856/763/83/85676383.geojson
@@ -303,6 +303,9 @@
     },
     "wof:concordances:hasc:id":"",
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"49befd921a8b686c114062d27f5ee577",
     "wof:hierarchy":[
         {
@@ -327,7 +330,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1561778476,
+    "wof:lastmodified":1582346745,
     "wof:name":"Caloocan",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/763/85/85676385.geojson
+++ b/data/856/763/85/85676385.geojson
@@ -225,6 +225,9 @@
     },
     "wof:concordances:hasc:id":"",
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5534877fed6f104c1f2131963f018e2e",
     "wof:hierarchy":[
         {
@@ -249,7 +252,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1561778476,
+    "wof:lastmodified":1582346745,
     "wof:name":"Malabon",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/763/89/85676389.geojson
+++ b/data/856/763/89/85676389.geojson
@@ -262,6 +262,9 @@
     },
     "wof:concordances:hasc:id":"",
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a8d64114511f1b95e5182ff61ab60511",
     "wof:hierarchy":[
         {
@@ -286,7 +289,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1561778476,
+    "wof:lastmodified":1582346744,
     "wof:name":"Valenzuela",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/763/95/85676395.geojson
+++ b/data/856/763/95/85676395.geojson
@@ -330,6 +330,9 @@
     },
     "wof:concordances:hasc:id":"",
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"875bdffc2b2f48871839702a7581403a",
     "wof:hierarchy":[
         {
@@ -354,7 +357,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1536616686,
+    "wof:lastmodified":1582346744,
     "wof:name":"Quezon City",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/763/99/85676399.geojson
+++ b/data/856/763/99/85676399.geojson
@@ -261,6 +261,9 @@
     },
     "wof:concordances:hasc:id":"",
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7b5f1b50b14b727636b019a4889ba6c8",
     "wof:hierarchy":[
         {
@@ -285,7 +288,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1561778476,
+    "wof:lastmodified":1582346745,
     "wof:name":"Marikina",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/764/03/85676403.geojson
+++ b/data/856/764/03/85676403.geojson
@@ -262,6 +262,9 @@
     },
     "wof:concordances:hasc:id":"",
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ca7feab7191d10f632ca5ed45e6c65bb",
     "wof:hierarchy":[
         {
@@ -286,7 +289,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1561778477,
+    "wof:lastmodified":1582346745,
     "wof:name":"San Juan",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/764/07/85676407.geojson
+++ b/data/856/764/07/85676407.geojson
@@ -262,6 +262,9 @@
     },
     "wof:concordances:hasc:id":"",
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4e34a784ebbfb2ad6ecd23eb846ce76c",
     "wof:hierarchy":[
         {
@@ -286,7 +289,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1561778477,
+    "wof:lastmodified":1582346745,
     "wof:name":"Pasig",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/764/13/85676413.geojson
+++ b/data/856/764/13/85676413.geojson
@@ -261,6 +261,9 @@
     },
     "wof:concordances:hasc:id":"",
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8c63a4171895d2ed829393f9832c9d01",
     "wof:hierarchy":[
         {
@@ -285,7 +288,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1561778477,
+    "wof:lastmodified":1582346745,
     "wof:name":"Makati",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/764/15/85676415.geojson
+++ b/data/856/764/15/85676415.geojson
@@ -262,6 +262,9 @@
     },
     "wof:concordances:hasc:id":"",
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c365b7d5736e31720ba65e2045e6687f",
     "wof:hierarchy":[
         {
@@ -286,7 +289,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1561778477,
+    "wof:lastmodified":1582346745,
     "wof:name":"Pasay",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/764/19/85676419.geojson
+++ b/data/856/764/19/85676419.geojson
@@ -277,6 +277,9 @@
     },
     "wof:concordances:hasc:id":"",
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"257b6b3a8729506b74ea0d6355292c14",
     "wof:hierarchy":[
         {
@@ -301,7 +304,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1561778477,
+    "wof:lastmodified":1582346745,
     "wof:name":"Paranaque",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/764/23/85676423.geojson
+++ b/data/856/764/23/85676423.geojson
@@ -280,6 +280,9 @@
     },
     "wof:concordances:hasc:id":"",
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ca9c4d4af9caa5b700735c7ddc34f0be",
     "wof:hierarchy":[
         {
@@ -304,7 +307,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1561778477,
+    "wof:lastmodified":1582346745,
     "wof:name":"Las Pinas",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/764/29/85676429.geojson
+++ b/data/856/764/29/85676429.geojson
@@ -262,6 +262,9 @@
     },
     "wof:concordances:hasc:id":"",
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c36c14c7bf4ff93bebfe061228dc8a9b",
     "wof:hierarchy":[
         {
@@ -286,7 +289,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1561778477,
+    "wof:lastmodified":1582346745,
     "wof:name":"Muntinlupa",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/764/33/85676433.geojson
+++ b/data/856/764/33/85676433.geojson
@@ -262,6 +262,9 @@
     },
     "wof:concordances:hasc:id":"",
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d237c929d6a223a4c276d6df28461246",
     "wof:hierarchy":[
         {
@@ -286,7 +289,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1561778477,
+    "wof:lastmodified":1582346745,
     "wof:name":"Taguig",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/764/37/85676437.geojson
+++ b/data/856/764/37/85676437.geojson
@@ -283,6 +283,9 @@
     },
     "wof:concordances:hasc:id":"",
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e40395ea84a52f92bd66a6f6e4fd9fb9",
     "wof:hierarchy":[
         {
@@ -307,7 +310,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1561778477,
+    "wof:lastmodified":1582346745,
     "wof:name":"Pateros",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/856/764/41/85676441.geojson
+++ b/data/856/764/41/85676441.geojson
@@ -344,6 +344,9 @@
     },
     "wof:concordances:hasc:id":"",
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d5d5c31878e9e99665de5958980c58ce",
     "wof:hierarchy":[
         {
@@ -368,7 +371,7 @@
         "mdh",
         "tsg"
     ],
-    "wof:lastmodified":1566679671,
+    "wof:lastmodified":1582346745,
     "wof:name":"Lucena",
     "wof:parent_id":85632509,
     "wof:placetype":"region",

--- a/data/857/718/23/85771823.geojson
+++ b/data/857/718/23/85771823.geojson
@@ -75,6 +75,9 @@
         "qs:id":484769
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9acf4727fffa8ee8393971b7f0ee85cc",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379405,
+    "wof:lastmodified":1582346743,
     "wof:name":"San Nicolas",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/027/75/85902775.geojson
+++ b/data/859/027/75/85902775.geojson
@@ -86,6 +86,9 @@
         "wd:id":"Q5055560"
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b1220c014bbb30f9799fd4f6a599e3bb",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1534379405,
+    "wof:lastmodified":1582346743,
     "wof:name":"Ca\u00f1acao",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/027/97/85902797.geojson
+++ b/data/859/027/97/85902797.geojson
@@ -226,6 +226,9 @@
         "qs_pg:id":287974
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f837f223991b737d3c23c24b5b6794ac",
     "wof:hierarchy":[
         {
@@ -241,7 +244,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566679667,
+    "wof:lastmodified":1582346743,
     "wof:name":"San Juan",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/027/99/85902799.geojson
+++ b/data/859/027/99/85902799.geojson
@@ -141,6 +141,9 @@
         "qs_pg:id":188539
     },
     "wof:country":"PH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"70b69253c616d480127c7420e8541438",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566679667,
+    "wof:lastmodified":1582346743,
     "wof:name":"San Roque",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/415/145/890415145.geojson
+++ b/data/890/415/145/890415145.geojson
@@ -66,6 +66,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469051075,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"41ba2d532e6e6316e84393cc33cfa3c1",
     "wof:hierarchy":[
         {
@@ -76,7 +79,7 @@
         }
     ],
     "wof:id":890415145,
-    "wof:lastmodified":1566681916,
+    "wof:lastmodified":1582346801,
     "wof:name":"Roxas City",
     "wof:parent_id":85675989,
     "wof:placetype":"county",

--- a/data/890/415/251/890415251.geojson
+++ b/data/890/415/251/890415251.geojson
@@ -216,6 +216,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469051080,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d56c37af51349d898d4f5e29a14c4cb3",
     "wof:hierarchy":[
         {
@@ -226,7 +229,7 @@
         }
     ],
     "wof:id":890415251,
-    "wof:lastmodified":1566681914,
+    "wof:lastmodified":1582346801,
     "wof:name":"Dumaguete City",
     "wof:parent_id":85675945,
     "wof:placetype":"county",

--- a/data/890/415/287/890415287.geojson
+++ b/data/890/415/287/890415287.geojson
@@ -63,6 +63,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469051081,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a8105bd792e828c4b430c2c0e96936d2",
     "wof:hierarchy":[
         {
@@ -73,7 +76,7 @@
         }
     ],
     "wof:id":890415287,
-    "wof:lastmodified":1566681910,
+    "wof:lastmodified":1582346801,
     "wof:name":"Canlaon City",
     "wof:parent_id":85675945,
     "wof:placetype":"county",

--- a/data/890/415/813/890415813.geojson
+++ b/data/890/415/813/890415813.geojson
@@ -67,6 +67,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469051106,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"adf21968a786ec7ccb0a6032e9c19e81",
     "wof:hierarchy":[
         {
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":890415813,
-    "wof:lastmodified":1566681926,
+    "wof:lastmodified":1582346801,
     "wof:name":"Malitbog",
     "wof:parent_id":1108697047,
     "wof:placetype":"locality",

--- a/data/890/415/953/890415953.geojson
+++ b/data/890/415/953/890415953.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469051113,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cb63ce5a3be443c2aa835e31a37ffea9",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":890415953,
-    "wof:lastmodified":1566681906,
+    "wof:lastmodified":1582346801,
     "wof:name":"Ipil",
     "wof:parent_id":1108697775,
     "wof:placetype":"locality",

--- a/data/890/415/975/890415975.geojson
+++ b/data/890/415/975/890415975.geojson
@@ -44,6 +44,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469051114,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2e0fda43ae87bf05771b6c03ecf0f93c",
     "wof:hierarchy":[
         {
@@ -55,7 +58,7 @@
         }
     ],
     "wof:id":890415975,
-    "wof:lastmodified":1566681933,
+    "wof:lastmodified":1582346801,
     "wof:name":"Estacion",
     "wof:parent_id":1108696669,
     "wof:placetype":"locality",

--- a/data/890/416/069/890416069.geojson
+++ b/data/890/416/069/890416069.geojson
@@ -101,6 +101,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469051118,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"be1b03722010f24509ba5782d9093fa6",
     "wof:hierarchy":[
         {
@@ -112,7 +115,7 @@
         }
     ],
     "wof:id":890416069,
-    "wof:lastmodified":1566682101,
+    "wof:lastmodified":1582346804,
     "wof:name":"Candelaria",
     "wof:parent_id":1108697245,
     "wof:placetype":"locality",

--- a/data/890/416/167/890416167.geojson
+++ b/data/890/416/167/890416167.geojson
@@ -194,6 +194,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469051122,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"247c5e3cac3f1a7c9d648c54d74b6b93",
     "wof:hierarchy":[
         {
@@ -205,7 +208,7 @@
         }
     ],
     "wof:id":890416167,
-    "wof:lastmodified":1566682089,
+    "wof:lastmodified":1582346804,
     "wof:name":"Bi\u00f1an",
     "wof:parent_id":1108697007,
     "wof:placetype":"locality",

--- a/data/890/416/211/890416211.geojson
+++ b/data/890/416/211/890416211.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469051124,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"11a83df3f2d95fa11a44895b82561869",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890416211,
-    "wof:lastmodified":1566682090,
+    "wof:lastmodified":1582346804,
     "wof:name":"Balibago",
     "wof:parent_id":1108696677,
     "wof:placetype":"locality",

--- a/data/890/416/227/890416227.geojson
+++ b/data/890/416/227/890416227.geojson
@@ -60,6 +60,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469051124,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"88c3fe71932190798c035f7b184a1928",
     "wof:hierarchy":[
         {
@@ -71,7 +74,7 @@
         }
     ],
     "wof:id":890416227,
-    "wof:lastmodified":1566682090,
+    "wof:lastmodified":1582346804,
     "wof:name":"Balas",
     "wof:parent_id":1108697989,
     "wof:placetype":"locality",

--- a/data/890/417/845/890417845.geojson
+++ b/data/890/417/845/890417845.geojson
@@ -235,6 +235,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469051222,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ac6aeff857b20789191c37da0d127214",
     "wof:hierarchy":[
         {
@@ -246,7 +249,7 @@
         }
     ],
     "wof:id":890417845,
-    "wof:lastmodified":1566682046,
+    "wof:lastmodified":1582346803,
     "wof:name":"Lourdes",
     "wof:parent_id":1108697243,
     "wof:placetype":"locality",

--- a/data/890/417/905/890417905.geojson
+++ b/data/890/417/905/890417905.geojson
@@ -104,6 +104,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469051226,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"de094defab2f264b6a4415ef0f675cd5",
     "wof:hierarchy":[
         {
@@ -115,7 +118,7 @@
         }
     ],
     "wof:id":890417905,
-    "wof:lastmodified":1566682048,
+    "wof:lastmodified":1582346803,
     "wof:name":"Santa Fe",
     "wof:parent_id":1108699361,
     "wof:placetype":"locality",

--- a/data/890/421/979/890421979.geojson
+++ b/data/890/421/979/890421979.geojson
@@ -111,6 +111,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469051422,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"11406a0bcc107a2a66cffac94fae2081",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
         }
     ],
     "wof:id":890421979,
-    "wof:lastmodified":1566682037,
+    "wof:lastmodified":1582346803,
     "wof:name":"Luna",
     "wof:parent_id":1108698161,
     "wof:placetype":"locality",

--- a/data/890/422/189/890422189.geojson
+++ b/data/890/422/189/890422189.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469051432,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"432d5d1480dfc91cd498ee752a4bb705",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":890422189,
-    "wof:lastmodified":1566681892,
+    "wof:lastmodified":1582346801,
     "wof:name":"Dulangan",
     "wof:parent_id":1108698881,
     "wof:placetype":"locality",

--- a/data/890/423/727/890423727.geojson
+++ b/data/890/423/727/890423727.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469051510,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"38413318e47cb3f1dc9877a11c6e2a3f",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890423727,
-    "wof:lastmodified":1566681934,
+    "wof:lastmodified":1582346801,
     "wof:name":"Brgy. Mobo, Kalibo",
     "wof:parent_id":1108697881,
     "wof:placetype":"locality",

--- a/data/890/428/927/890428927.geojson
+++ b/data/890/428/927/890428927.geojson
@@ -87,6 +87,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469051780,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"31cb2539e8011cee5eea34960d9cc812",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":890428927,
-    "wof:lastmodified":1566682045,
+    "wof:lastmodified":1582346803,
     "wof:name":"Biga",
     "wof:parent_id":1108697213,
     "wof:placetype":"locality",

--- a/data/890/429/615/890429615.geojson
+++ b/data/890/429/615/890429615.geojson
@@ -70,6 +70,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469051822,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e1413f004dcb4e743f23e6a9e2cf00d2",
     "wof:hierarchy":[
         {
@@ -80,7 +83,7 @@
         }
     ],
     "wof:id":890429615,
-    "wof:lastmodified":1566682086,
+    "wof:lastmodified":1582346804,
     "wof:name":"Tangub City",
     "wof:parent_id":85675971,
     "wof:placetype":"county",

--- a/data/890/429/635/890429635.geojson
+++ b/data/890/429/635/890429635.geojson
@@ -306,6 +306,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469051823,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"81b3e09dffe2b5f05460c0fe88233939",
     "wof:hierarchy":[
         {
@@ -316,7 +319,7 @@
         }
     ],
     "wof:id":890429635,
-    "wof:lastmodified":1566682083,
+    "wof:lastmodified":1582346804,
     "wof:name":"Quezon",
     "wof:parent_id":85676161,
     "wof:placetype":"county",

--- a/data/890/429/639/890429639.geojson
+++ b/data/890/429/639/890429639.geojson
@@ -198,6 +198,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469051823,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a3d755e80f04cc615580430e94e4613f",
     "wof:hierarchy":[
         {
@@ -208,7 +211,7 @@
         }
     ],
     "wof:id":890429639,
-    "wof:lastmodified":1566682086,
+    "wof:lastmodified":1582346804,
     "wof:name":"Pagadian City",
     "wof:parent_id":85675967,
     "wof:placetype":"county",

--- a/data/890/429/659/890429659.geojson
+++ b/data/890/429/659/890429659.geojson
@@ -69,6 +69,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469051824,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7fb2ce9004e173c642f7bbe3bfdd266c",
     "wof:hierarchy":[
         {
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":890429659,
-    "wof:lastmodified":1566682084,
+    "wof:lastmodified":1582346804,
     "wof:name":"Ozamis City",
     "wof:parent_id":85675971,
     "wof:placetype":"county",

--- a/data/890/430/027/890430027.geojson
+++ b/data/890/430/027/890430027.geojson
@@ -217,6 +217,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469051837,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"28cfd35b7b25fa24b34ea5cb969a3d13",
     "wof:hierarchy":[
         {
@@ -227,7 +230,7 @@
         }
     ],
     "wof:id":890430027,
-    "wof:lastmodified":1566681943,
+    "wof:lastmodified":1582346802,
     "wof:name":"Iloilo City",
     "wof:parent_id":85676299,
     "wof:placetype":"county",

--- a/data/890/430/319/890430319.geojson
+++ b/data/890/430/319/890430319.geojson
@@ -198,6 +198,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469051847,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e7c52479b510a95ee23ad896aa1c326c",
     "wof:hierarchy":[
         {
@@ -208,7 +211,7 @@
         }
     ],
     "wof:id":890430319,
-    "wof:lastmodified":1566681946,
+    "wof:lastmodified":1582346802,
     "wof:name":"Tagaytay City",
     "wof:parent_id":85676127,
     "wof:placetype":"county",

--- a/data/890/431/621/890431621.geojson
+++ b/data/890/431/621/890431621.geojson
@@ -232,6 +232,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469051900,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d95d67ed0b9540930d425fe73e43ebd5",
     "wof:hierarchy":[
         {
@@ -243,7 +246,7 @@
         }
     ],
     "wof:id":890431621,
-    "wof:lastmodified":1566681989,
+    "wof:lastmodified":1582346802,
     "wof:name":"San Jose",
     "wof:parent_id":1108699051,
     "wof:placetype":"locality",

--- a/data/890/431/639/890431639.geojson
+++ b/data/890/431/639/890431639.geojson
@@ -122,6 +122,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469051901,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"25cc44465423b23041dd09606435e244",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":890431639,
-    "wof:lastmodified":1566682003,
+    "wof:lastmodified":1582346802,
     "wof:name":"San Andres",
     "wof:parent_id":1108696737,
     "wof:placetype":"locality",

--- a/data/890/431/797/890431797.geojson
+++ b/data/890/431/797/890431797.geojson
@@ -157,6 +157,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469051915,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bde3e596a094fc7cc95674d9b00f38e5",
     "wof:hierarchy":[
         {
@@ -168,7 +171,7 @@
         }
     ],
     "wof:id":890431797,
-    "wof:lastmodified":1566681985,
+    "wof:lastmodified":1582346802,
     "wof:name":"Guadalupe",
     "wof:parent_id":1108697577,
     "wof:placetype":"locality",

--- a/data/890/431/855/890431855.geojson
+++ b/data/890/431/855/890431855.geojson
@@ -53,6 +53,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469051918,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d978fa4c137903505e9036593efd5186",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":890431855,
-    "wof:lastmodified":1566682003,
+    "wof:lastmodified":1582346803,
     "wof:name":"De la Paz",
     "wof:parent_id":1108697395,
     "wof:placetype":"locality",

--- a/data/890/431/907/890431907.geojson
+++ b/data/890/431/907/890431907.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469051920,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8f77ef85eba245f8c8292d4ee8cb1f38",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890431907,
-    "wof:lastmodified":1566681985,
+    "wof:lastmodified":1582346802,
     "wof:name":"Cabay",
     "wof:parent_id":1108697245,
     "wof:placetype":"locality",

--- a/data/890/432/457/890432457.geojson
+++ b/data/890/432/457/890432457.geojson
@@ -103,6 +103,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469051941,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"32d75b76088a14e105c924ced0fa1d9e",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":890432457,
-    "wof:lastmodified":1566682244,
+    "wof:lastmodified":1582346806,
     "wof:name":"Salcedo",
     "wof:parent_id":1108696889,
     "wof:placetype":"locality",

--- a/data/890/432/683/890432683.geojson
+++ b/data/890/432/683/890432683.geojson
@@ -354,6 +354,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469051950,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"685eaaf4e5b28379180dd5508499ab32",
     "wof:hierarchy":[
         {
@@ -365,7 +368,7 @@
         }
     ],
     "wof:id":890432683,
-    "wof:lastmodified":1566682242,
+    "wof:lastmodified":1582346806,
     "wof:name":"Santo Domingo",
     "wof:parent_id":1108699417,
     "wof:placetype":"localadmin",

--- a/data/890/432/695/890432695.geojson
+++ b/data/890/432/695/890432695.geojson
@@ -140,6 +140,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469051950,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1bcc71b4106cf7135bcfa4ca3478b08d",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":890432695,
-    "wof:lastmodified":1566682230,
+    "wof:lastmodified":1582346806,
     "wof:name":"San Pablo City",
     "wof:parent_id":85676141,
     "wof:placetype":"county",

--- a/data/890/432/817/890432817.geojson
+++ b/data/890/432/817/890432817.geojson
@@ -66,6 +66,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469051955,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0a62f0d33fc39d0bda9ef5bef00eec32",
     "wof:hierarchy":[
         {
@@ -76,7 +79,7 @@
         }
     ],
     "wof:id":890432817,
-    "wof:lastmodified":1566682225,
+    "wof:lastmodified":1582346806,
     "wof:name":"Lipa City",
     "wof:parent_id":85676131,
     "wof:placetype":"county",

--- a/data/890/432/905/890432905.geojson
+++ b/data/890/432/905/890432905.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469051959,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f2309b088999223e0530dd3ffdab108f",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":890432905,
-    "wof:lastmodified":1566682238,
+    "wof:lastmodified":1582346806,
     "wof:name":"Compostela",
     "wof:parent_id":85676235,
     "wof:placetype":"county",

--- a/data/890/432/909/890432909.geojson
+++ b/data/890/432/909/890432909.geojson
@@ -301,6 +301,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469051959,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"66cde552720492b3f3cb9e673fbbb4ed",
     "wof:hierarchy":[
         {
@@ -311,7 +314,7 @@
         }
     ],
     "wof:id":890432909,
-    "wof:lastmodified":1566682220,
+    "wof:lastmodified":1582346806,
     "wof:name":"Cebu City",
     "wof:parent_id":85675939,
     "wof:placetype":"county",

--- a/data/890/433/167/890433167.geojson
+++ b/data/890/433/167/890433167.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469051969,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"10c0e20876ee44413b5a437075050fab",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890433167,
-    "wof:lastmodified":1566682167,
+    "wof:lastmodified":1582346805,
     "wof:name":"Anuling",
     "wof:parent_id":1108698837,
     "wof:placetype":"locality",

--- a/data/890/433/179/890433179.geojson
+++ b/data/890/433/179/890433179.geojson
@@ -103,6 +103,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469051970,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"36e2721c9d4ce1eed9e793b6e9f81329",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":890433179,
-    "wof:lastmodified":1566682183,
+    "wof:lastmodified":1582346805,
     "wof:name":"Murcia",
     "wof:parent_id":1108699649,
     "wof:placetype":"locality",

--- a/data/890/433/743/890433743.geojson
+++ b/data/890/433/743/890433743.geojson
@@ -50,6 +50,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469051992,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dee251953ae1c673a975f68f805ae4e3",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":890433743,
-    "wof:lastmodified":1566682182,
+    "wof:lastmodified":1582346805,
     "wof:name":"Unidos",
     "wof:parent_id":1108698919,
     "wof:placetype":"locality",

--- a/data/890/433/929/890433929.geojson
+++ b/data/890/433/929/890433929.geojson
@@ -264,6 +264,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052000,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"974f5f40b69c17829c5a7aa6086c4c5d",
     "wof:hierarchy":[
         {
@@ -275,7 +278,7 @@
         }
     ],
     "wof:id":890433929,
-    "wof:lastmodified":1561778754,
+    "wof:lastmodified":1582346805,
     "wof:name":"Tagum",
     "wof:parent_id":1108699621,
     "wof:placetype":"locality",

--- a/data/890/433/951/890433951.geojson
+++ b/data/890/433/951/890433951.geojson
@@ -110,6 +110,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052002,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"50797d576ebcab3dfddf121662e406a9",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":890433951,
-    "wof:lastmodified":1566682176,
+    "wof:lastmodified":1582346805,
     "wof:name":"Subic",
     "wof:parent_id":1108699545,
     "wof:placetype":"locality",

--- a/data/890/433/953/890433953.geojson
+++ b/data/890/433/953/890433953.geojson
@@ -108,6 +108,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052003,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"803937133052162518312fc2d8fe5189",
     "wof:hierarchy":[
         {
@@ -119,7 +122,7 @@
         }
     ],
     "wof:id":890433953,
-    "wof:lastmodified":1566682166,
+    "wof:lastmodified":1582346805,
     "wof:name":"Sual",
     "wof:parent_id":1108699543,
     "wof:placetype":"locality",

--- a/data/890/434/093/890434093.geojson
+++ b/data/890/434/093/890434093.geojson
@@ -103,6 +103,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052010,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"155436ae54b338a03a3fbc228196475a",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":890434093,
-    "wof:lastmodified":1566682161,
+    "wof:lastmodified":1582346805,
     "wof:name":"Pontevedra",
     "wof:parent_id":1108698937,
     "wof:placetype":"locality",

--- a/data/890/434/321/890434321.geojson
+++ b/data/890/434/321/890434321.geojson
@@ -50,6 +50,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052020,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"00c02a286c15cf8e265f331d1ee475e1",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":890434321,
-    "wof:lastmodified":1566682164,
+    "wof:lastmodified":1582346805,
     "wof:name":"Japitan",
     "wof:parent_id":1108696907,
     "wof:placetype":"locality",

--- a/data/890/434/451/890434451.geojson
+++ b/data/890/434/451/890434451.geojson
@@ -50,6 +50,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052025,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a56f3150923160fe749f67692536f073",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":890434451,
-    "wof:lastmodified":1566682158,
+    "wof:lastmodified":1582346805,
     "wof:name":"Buayan",
     "wof:parent_id":1108697635,
     "wof:placetype":"locality",

--- a/data/890/434/457/890434457.geojson
+++ b/data/890/434/457/890434457.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052025,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"04f771cdb97a79bd5082d94667f895ef",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890434457,
-    "wof:lastmodified":1566682160,
+    "wof:lastmodified":1582346805,
     "wof:name":"Bualan",
     "wof:parent_id":1108698155,
     "wof:placetype":"locality",

--- a/data/890/434/473/890434473.geojson
+++ b/data/890/434/473/890434473.geojson
@@ -54,6 +54,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052026,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"73b38564dd4de290ffc6f6871c03a5fc",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890434473,
-    "wof:lastmodified":1566682157,
+    "wof:lastmodified":1582346805,
     "wof:name":"Biao",
     "wof:parent_id":1108698611,
     "wof:placetype":"locality",

--- a/data/890/435/005/890435005.geojson
+++ b/data/890/435/005/890435005.geojson
@@ -56,6 +56,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052048,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"63b199acd5e6eead109e7f1e6434295b",
     "wof:hierarchy":[
         {
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":890435005,
-    "wof:lastmodified":1566682254,
+    "wof:lastmodified":1582346806,
     "wof:name":"Calumpang",
     "wof:parent_id":1159397243,
     "wof:placetype":"locality",

--- a/data/890/435/679/890435679.geojson
+++ b/data/890/435/679/890435679.geojson
@@ -61,6 +61,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052077,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fa94a9e82c4f5291fe5724fb5bc708ba",
     "wof:hierarchy":[
         {
@@ -72,7 +75,7 @@
         }
     ],
     "wof:id":890435679,
-    "wof:lastmodified":1566682253,
+    "wof:lastmodified":1582346806,
     "wof:name":"Nangka",
     "wof:parent_id":1108696805,
     "wof:placetype":"locality",

--- a/data/890/435/733/890435733.geojson
+++ b/data/890/435/733/890435733.geojson
@@ -166,6 +166,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052079,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"99e5d54713b74239208f200851f95642",
     "wof:hierarchy":[
         {
@@ -177,7 +180,7 @@
         }
     ],
     "wof:id":890435733,
-    "wof:lastmodified":1566682252,
+    "wof:lastmodified":1582346806,
     "wof:name":"Santa Ana",
     "wof:parent_id":1108699775,
     "wof:placetype":"locality",

--- a/data/890/435/939/890435939.geojson
+++ b/data/890/435/939/890435939.geojson
@@ -53,6 +53,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052087,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a2179b6b7ead4ef95229baf4340a7001",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":890435939,
-    "wof:lastmodified":1566682251,
+    "wof:lastmodified":1582346806,
     "wof:name":"City of Talisay",
     "wof:parent_id":1108699649,
     "wof:placetype":"localadmin",

--- a/data/890/436/295/890436295.geojson
+++ b/data/890/436/295/890436295.geojson
@@ -202,6 +202,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052106,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2ce7a3e7581ec17dcc277c1817f2c8f1",
     "wof:hierarchy":[
         {
@@ -212,7 +215,7 @@
         }
     ],
     "wof:id":890436295,
-    "wof:lastmodified":1566681978,
+    "wof:lastmodified":1582346802,
     "wof:name":"Oroquieta City",
     "wof:parent_id":85675971,
     "wof:placetype":"county",

--- a/data/890/436/337/890436337.geojson
+++ b/data/890/436/337/890436337.geojson
@@ -58,6 +58,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052108,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7a88279c68c7fdf20aa60ba87338885f",
     "wof:hierarchy":[
         {
@@ -69,7 +72,7 @@
         }
     ],
     "wof:id":890436337,
-    "wof:lastmodified":1566681976,
+    "wof:lastmodified":1582346802,
     "wof:name":"Basak",
     "wof:parent_id":1108698037,
     "wof:placetype":"locality",

--- a/data/890/437/307/890437307.geojson
+++ b/data/890/437/307/890437307.geojson
@@ -282,6 +282,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052146,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"5e70cd4a12c5ce310449102dd870f244",
     "wof:hierarchy":[
         {
@@ -292,7 +295,7 @@
         }
     ],
     "wof:id":890437307,
-    "wof:lastmodified":1566681947,
+    "wof:lastmodified":1582346802,
     "wof:name":"San Carlos",
     "wof:parent_id":85675951,
     "wof:placetype":"locality",

--- a/data/890/437/629/890437629.geojson
+++ b/data/890/437/629/890437629.geojson
@@ -64,6 +64,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052159,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"521b47a59f315f65ace5b9fc2d5a57fb",
     "wof:hierarchy":[
         {
@@ -74,7 +77,7 @@
         }
     ],
     "wof:id":890437629,
-    "wof:lastmodified":1566681950,
+    "wof:lastmodified":1582346802,
     "wof:name":"Province of Masbate",
     "wof:parent_id":85676029,
     "wof:placetype":"county",

--- a/data/890/437/821/890437821.geojson
+++ b/data/890/437/821/890437821.geojson
@@ -50,6 +50,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052167,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f301574a364160f16f22dddffa05d04f",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":890437821,
-    "wof:lastmodified":1566681949,
+    "wof:lastmodified":1582346802,
     "wof:name":"Baliwagan",
     "wof:parent_id":1108699135,
     "wof:placetype":"locality",

--- a/data/890/438/077/890438077.geojson
+++ b/data/890/438/077/890438077.geojson
@@ -235,6 +235,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052179,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3fd228ce978c0106923377f0867664e4",
     "wof:hierarchy":[
         {
@@ -246,7 +249,7 @@
         }
     ],
     "wof:id":890438077,
-    "wof:lastmodified":1566682010,
+    "wof:lastmodified":1582346803,
     "wof:name":"San Jose",
     "wof:parent_id":1108699215,
     "wof:placetype":"localadmin",

--- a/data/890/438/385/890438385.geojson
+++ b/data/890/438/385/890438385.geojson
@@ -204,6 +204,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052192,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"354d10ccacdbf0212e09342cff351bea",
     "wof:hierarchy":[
         {
@@ -214,7 +217,7 @@
         }
     ],
     "wof:id":890438385,
-    "wof:lastmodified":1566682014,
+    "wof:lastmodified":1582346803,
     "wof:name":"Trece Martirez City",
     "wof:parent_id":85676127,
     "wof:placetype":"county",

--- a/data/890/438/513/890438513.geojson
+++ b/data/890/438/513/890438513.geojson
@@ -53,6 +53,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052198,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e0e112c9b33fdb62d645e635a33022a4",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":890438513,
-    "wof:lastmodified":1566682021,
+    "wof:lastmodified":1582346803,
     "wof:name":"City of San Fernando",
     "wof:parent_id":1108699151,
     "wof:placetype":"localadmin",

--- a/data/890/438/593/890438593.geojson
+++ b/data/890/438/593/890438593.geojson
@@ -275,6 +275,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052201,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8362a7eec4a14517d3631db73f6790f5",
     "wof:hierarchy":[
         {
@@ -286,7 +289,7 @@
         }
     ],
     "wof:id":890438593,
-    "wof:lastmodified":1566682008,
+    "wof:lastmodified":1582346803,
     "wof:name":"San Mateo",
     "wof:parent_id":1108698227,
     "wof:placetype":"locality",

--- a/data/890/438/623/890438623.geojson
+++ b/data/890/438/623/890438623.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052202,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"752d1934e5396e366d972c35218de9bb",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890438623,
-    "wof:lastmodified":1566682018,
+    "wof:lastmodified":1582346803,
     "wof:name":"Lantangan",
     "wof:parent_id":1108698347,
     "wof:placetype":"locality",

--- a/data/890/438/681/890438681.geojson
+++ b/data/890/438/681/890438681.geojson
@@ -66,6 +66,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052205,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6260b3b7c2647a8eac2c6b39e1c035f6",
     "wof:hierarchy":[
         {
@@ -77,7 +80,7 @@
         }
     ],
     "wof:id":890438681,
-    "wof:lastmodified":1566682009,
+    "wof:lastmodified":1582346803,
     "wof:name":"Carmelo",
     "wof:parent_id":1108696865,
     "wof:placetype":"locality",

--- a/data/890/440/023/890440023.geojson
+++ b/data/890/440/023/890440023.geojson
@@ -271,6 +271,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052259,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"174eb65c1311ff066c74a80b1e229926",
     "wof:hierarchy":[
         {
@@ -282,7 +285,7 @@
         }
     ],
     "wof:id":890440023,
-    "wof:lastmodified":1566681883,
+    "wof:lastmodified":1582346801,
     "wof:name":"Pagadian",
     "wof:parent_id":890429639,
     "wof:placetype":"locality",

--- a/data/890/440/031/890440031.geojson
+++ b/data/890/440/031/890440031.geojson
@@ -104,6 +104,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052260,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"edae496ab59d8a67009c9b4096004468",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":890440031,
-    "wof:lastmodified":1566681885,
+    "wof:lastmodified":1582346801,
     "wof:name":"General Luna",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/440/037/890440037.geojson
+++ b/data/890/440/037/890440037.geojson
@@ -112,6 +112,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052260,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4629613d3f3932745f09549fc3840f29",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":890440037,
-    "wof:lastmodified":1566681885,
+    "wof:lastmodified":1582346801,
     "wof:name":"Balete",
     "wof:parent_id":1108696829,
     "wof:placetype":"locality",

--- a/data/890/440/465/890440465.geojson
+++ b/data/890/440/465/890440465.geojson
@@ -186,6 +186,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052278,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1f3cedf223ab46d1192c586faeba2596",
     "wof:hierarchy":[
         {
@@ -197,7 +200,7 @@
         }
     ],
     "wof:id":890440465,
-    "wof:lastmodified":1566681886,
+    "wof:lastmodified":1582346801,
     "wof:name":"Sagay",
     "wof:parent_id":1108699073,
     "wof:placetype":"locality",

--- a/data/890/441/517/890441517.geojson
+++ b/data/890/441/517/890441517.geojson
@@ -102,6 +102,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052326,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"83375f11c47b2e14dc75b14085cc2239",
     "wof:hierarchy":[
         {
@@ -112,7 +115,7 @@
         }
     ],
     "wof:id":890441517,
-    "wof:lastmodified":1566681900,
+    "wof:lastmodified":1582346801,
     "wof:name":"La Carlota City",
     "wof:parent_id":85675951,
     "wof:placetype":"county",

--- a/data/890/441/551/890441551.geojson
+++ b/data/890/441/551/890441551.geojson
@@ -98,6 +98,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052328,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"19ad68cbe5a2aa50871aad10e23bd57c",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
         }
     ],
     "wof:id":890441551,
-    "wof:lastmodified":1566681897,
+    "wof:lastmodified":1582346801,
     "wof:name":"Badian",
     "wof:parent_id":1108696769,
     "wof:placetype":"locality",

--- a/data/890/442/461/890442461.geojson
+++ b/data/890/442/461/890442461.geojson
@@ -63,6 +63,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052363,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3fb3c0983a90ef363e14fc85b248dd1b",
     "wof:hierarchy":[
         {
@@ -73,7 +76,7 @@
         }
     ],
     "wof:id":890442461,
-    "wof:lastmodified":1566682115,
+    "wof:lastmodified":1582346804,
     "wof:name":"San Jose City",
     "wof:parent_id":85676101,
     "wof:placetype":"county",

--- a/data/890/442/475/890442475.geojson
+++ b/data/890/442/475/890442475.geojson
@@ -67,6 +67,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052364,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6cc3346bc7863d34d04b53c28fee9919",
     "wof:hierarchy":[
         {
@@ -77,7 +80,7 @@
         }
     ],
     "wof:id":890442475,
-    "wof:lastmodified":1566682113,
+    "wof:lastmodified":1582346804,
     "wof:name":"Laoag City",
     "wof:parent_id":85676057,
     "wof:placetype":"county",

--- a/data/890/442/489/890442489.geojson
+++ b/data/890/442/489/890442489.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052364,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"096bf2cc95c90f11e0a1cab579ec54b3",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":890442489,
-    "wof:lastmodified":1566682114,
+    "wof:lastmodified":1582346804,
     "wof:name":"Alcala",
     "wof:parent_id":1108696603,
     "wof:placetype":"locality",

--- a/data/890/442/853/890442853.geojson
+++ b/data/890/442/853/890442853.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052383,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d839b3dc74a81d89c5013919602dfe38",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890442853,
-    "wof:lastmodified":1566682115,
+    "wof:lastmodified":1582346804,
     "wof:name":"Calaba",
     "wof:parent_id":1108699187,
     "wof:placetype":"locality",

--- a/data/890/443/085/890443085.geojson
+++ b/data/890/443/085/890443085.geojson
@@ -204,6 +204,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052399,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5d956946cef8c3c9551486b2a8673497",
     "wof:hierarchy":[
         {
@@ -214,7 +217,7 @@
         }
     ],
     "wof:id":890443085,
-    "wof:lastmodified":1566682062,
+    "wof:lastmodified":1582346804,
     "wof:name":"Cabanatuan City",
     "wof:parent_id":85676101,
     "wof:placetype":"county",

--- a/data/890/443/951/890443951.geojson
+++ b/data/890/443/951/890443951.geojson
@@ -58,6 +58,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052444,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f329577cde26f8d91a3f327dfd30edf3",
     "wof:hierarchy":[
         {
@@ -69,7 +72,7 @@
         }
     ],
     "wof:id":890443951,
-    "wof:lastmodified":1566682071,
+    "wof:lastmodified":1582346804,
     "wof:name":"Sabang",
     "wof:parent_id":1108698559,
     "wof:placetype":"locality",

--- a/data/890/444/055/890444055.geojson
+++ b/data/890/444/055/890444055.geojson
@@ -50,6 +50,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052449,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5ab3b5b1fef9b723e3826cc7bb481805",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":890444055,
-    "wof:lastmodified":1566682052,
+    "wof:lastmodified":1582346803,
     "wof:name":"Cawayan",
     "wof:parent_id":1108698577,
     "wof:placetype":"locality",

--- a/data/890/450/647/890450647.geojson
+++ b/data/890/450/647/890450647.geojson
@@ -82,6 +82,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052748,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c7477d1134bbf4e42930366211ebe895",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":890450647,
-    "wof:lastmodified":1566682209,
+    "wof:lastmodified":1582346806,
     "wof:name":"San Agustin",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/450/695/890450695.geojson
+++ b/data/890/450/695/890450695.geojson
@@ -145,6 +145,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052750,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"060bd43797f07be00f012c5e9b28c7eb",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
         }
     ],
     "wof:id":890450695,
-    "wof:lastmodified":1566682197,
+    "wof:lastmodified":1582346806,
     "wof:name":"Rizal",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/450/827/890450827.geojson
+++ b/data/890/450/827/890450827.geojson
@@ -91,6 +91,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052755,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7b1b2ab684f77f6c6f5172ccce26776d",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":890450827,
-    "wof:lastmodified":1566682189,
+    "wof:lastmodified":1582346805,
     "wof:name":"Municipality of Pata",
     "wof:parent_id":1108698835,
     "wof:placetype":"localadmin",

--- a/data/890/451/079/890451079.geojson
+++ b/data/890/451/079/890451079.geojson
@@ -78,6 +78,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052764,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"292c3d9548da19f4cf6667e2e78012af",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
         }
     ],
     "wof:id":890451079,
-    "wof:lastmodified":1566682121,
+    "wof:lastmodified":1582346805,
     "wof:name":"Mabini",
     "wof:parent_id":1108698103,
     "wof:placetype":"locality",

--- a/data/890/451/133/890451133.geojson
+++ b/data/890/451/133/890451133.geojson
@@ -332,6 +332,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052766,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d9cf8e3566e33b1ce57314281408ab11",
     "wof:hierarchy":[
         {
@@ -343,7 +346,7 @@
         }
     ],
     "wof:id":890451133,
-    "wof:lastmodified":1566682119,
+    "wof:lastmodified":1582346805,
     "wof:name":"Liberty",
     "wof:parent_id":1108699657,
     "wof:placetype":"locality",

--- a/data/890/451/311/890451311.geojson
+++ b/data/890/451/311/890451311.geojson
@@ -107,6 +107,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052773,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"93cd7d3187a95600a649b7d2d02966a7",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
         }
     ],
     "wof:id":890451311,
-    "wof:lastmodified":1566682137,
+    "wof:lastmodified":1582346805,
     "wof:name":"Gamut",
     "wof:parent_id":1108696913,
     "wof:placetype":"locality",

--- a/data/890/451/393/890451393.geojson
+++ b/data/890/451/393/890451393.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052777,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"954b7bf703818a18410c4dcb22aa8134",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890451393,
-    "wof:lastmodified":1566682130,
+    "wof:lastmodified":1582346805,
     "wof:name":"Dagatan",
     "wof:parent_id":1108697519,
     "wof:placetype":"locality",

--- a/data/890/451/429/890451429.geojson
+++ b/data/890/451/429/890451429.geojson
@@ -67,6 +67,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052778,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7820a1b8afaa5a7a9c036b8ae5dcb702",
     "wof:hierarchy":[
         {
@@ -77,7 +80,7 @@
         }
     ],
     "wof:id":890451429,
-    "wof:lastmodified":1566682132,
+    "wof:lastmodified":1582346805,
     "wof:name":"Bais City",
     "wof:parent_id":85675945,
     "wof:placetype":"county",

--- a/data/890/451/595/890451595.geojson
+++ b/data/890/451/595/890451595.geojson
@@ -62,6 +62,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052786,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f79bbda3c29f24573df1aa2743e28abf",
     "wof:hierarchy":[
         {
@@ -73,7 +76,7 @@
         }
     ],
     "wof:id":890451595,
-    "wof:lastmodified":1566682118,
+    "wof:lastmodified":1582346804,
     "wof:name":"Buga",
     "wof:parent_id":1108698073,
     "wof:placetype":"locality",

--- a/data/890/452/553/890452553.geojson
+++ b/data/890/452/553/890452553.geojson
@@ -122,6 +122,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052822,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"68819f8eaef7f8b304a633d1afd854da",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":890452553,
-    "wof:lastmodified":1566681967,
+    "wof:lastmodified":1582346802,
     "wof:name":"Barra",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/452/681/890452681.geojson
+++ b/data/890/452/681/890452681.geojson
@@ -53,6 +53,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052826,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"41d468af3feefb7302bd1c6db2c1ee0e",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":890452681,
-    "wof:lastmodified":1566681961,
+    "wof:lastmodified":1582346802,
     "wof:name":"Ambulong",
     "wof:parent_id":1108696937,
     "wof:placetype":"locality",

--- a/data/890/453/523/890453523.geojson
+++ b/data/890/453/523/890453523.geojson
@@ -101,6 +101,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052857,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"358e65241726edf4fbf613e4ef1cf7b9",
     "wof:hierarchy":[
         {
@@ -112,7 +115,7 @@
         }
     ],
     "wof:id":890453523,
-    "wof:lastmodified":1566682032,
+    "wof:lastmodified":1582346803,
     "wof:name":"Cabatuan",
     "wof:parent_id":1108697163,
     "wof:placetype":"locality",

--- a/data/890/453/527/890453527.geojson
+++ b/data/890/453/527/890453527.geojson
@@ -75,6 +75,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052857,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"be0042e213f01ac209403eb0b25b189a",
     "wof:hierarchy":[
         {
@@ -86,7 +89,7 @@
         }
     ],
     "wof:id":890453527,
-    "wof:lastmodified":1566682029,
+    "wof:lastmodified":1582346803,
     "wof:name":"Bonga",
     "wof:parent_id":1108698083,
     "wof:placetype":"locality",

--- a/data/890/453/965/890453965.geojson
+++ b/data/890/453/965/890453965.geojson
@@ -199,6 +199,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052880,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6defe180be8b67c258e6cec1fe7d7642",
     "wof:hierarchy":[
         {
@@ -209,7 +212,7 @@
         }
     ],
     "wof:id":890453965,
-    "wof:lastmodified":1566682027,
+    "wof:lastmodified":1582346803,
     "wof:name":"Surigao City",
     "wof:parent_id":85676239,
     "wof:placetype":"county",

--- a/data/890/454/003/890454003.geojson
+++ b/data/890/454/003/890454003.geojson
@@ -67,6 +67,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052881,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"748e7b8fcb13f43cf9fd3f83adea08be",
     "wof:hierarchy":[
         {
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":890454003,
-    "wof:lastmodified":1566682025,
+    "wof:lastmodified":1582346803,
     "wof:name":"Salvacion",
     "wof:parent_id":1108697081,
     "wof:placetype":"locality",

--- a/data/890/454/007/890454007.geojson
+++ b/data/890/454/007/890454007.geojson
@@ -206,6 +206,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052882,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7bfc3a25af7a31c43cf7cdba31861d36",
     "wof:hierarchy":[
         {
@@ -217,7 +220,7 @@
         }
     ],
     "wof:id":890454007,
-    "wof:lastmodified":1566682023,
+    "wof:lastmodified":1582346803,
     "wof:name":"Marawi",
     "wof:parent_id":1108698387,
     "wof:placetype":"locality",

--- a/data/890/454/025/890454025.geojson
+++ b/data/890/454/025/890454025.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052882,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6a218a8c081ce03b4233dbe284bd126e",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890454025,
-    "wof:lastmodified":1566682023,
+    "wof:lastmodified":1582346803,
     "wof:name":"Libas",
     "wof:parent_id":1108697467,
     "wof:placetype":"locality",

--- a/data/890/454/043/890454043.geojson
+++ b/data/890/454/043/890454043.geojson
@@ -46,6 +46,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052883,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a5c53b7bd561009dad0db215a7739ff5",
     "wof:hierarchy":[
         {
@@ -57,7 +60,7 @@
         }
     ],
     "wof:id":890454043,
-    "wof:lastmodified":1566682025,
+    "wof:lastmodified":1582346803,
     "wof:name":"Lambakin",
     "wof:parent_id":1108697101,
     "wof:placetype":"locality",

--- a/data/890/454/063/890454063.geojson
+++ b/data/890/454/063/890454063.geojson
@@ -100,6 +100,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052884,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c045d1b978033d969697b67956e473ca",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":890454063,
-    "wof:lastmodified":1566682024,
+    "wof:lastmodified":1582346803,
     "wof:name":"Buan",
     "wof:parent_id":1108699463,
     "wof:placetype":"locality",

--- a/data/890/455/201/890455201.geojson
+++ b/data/890/455/201/890455201.geojson
@@ -159,6 +159,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052937,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1580df739895c1019630a0830cf49156",
     "wof:hierarchy":[
         {
@@ -169,7 +172,7 @@
         }
     ],
     "wof:id":890455201,
-    "wof:lastmodified":1566681975,
+    "wof:lastmodified":1582346802,
     "wof:name":"Sorsogon",
     "wof:parent_id":85676035,
     "wof:placetype":"county",

--- a/data/890/455/737/890455737.geojson
+++ b/data/890/455/737/890455737.geojson
@@ -147,6 +147,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052973,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0ce5818e7c103bfee7bda792071d0054",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
         }
     ],
     "wof:id":890455737,
-    "wof:lastmodified":1566681973,
+    "wof:lastmodified":1582346802,
     "wof:name":"Dinagat",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/455/961/890455961.geojson
+++ b/data/890/455/961/890455961.geojson
@@ -50,6 +50,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052987,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0d56fff7bd09f39b7da0b9db0f04d836",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":890455961,
-    "wof:lastmodified":1566681974,
+    "wof:lastmodified":1582346802,
     "wof:name":"Upi",
     "wof:parent_id":1108697605,
     "wof:placetype":"locality",

--- a/data/890/455/971/890455971.geojson
+++ b/data/890/455/971/890455971.geojson
@@ -317,6 +317,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052987,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"502c41a79840250ee1a62cc73efd3bd3",
     "wof:hierarchy":[
         {
@@ -328,7 +331,7 @@
         }
     ],
     "wof:id":890455971,
-    "wof:lastmodified":1566681974,
+    "wof:lastmodified":1582346802,
     "wof:name":"Santa Maria",
     "wof:parent_id":1108698079,
     "wof:placetype":"locality",

--- a/data/890/455/985/890455985.geojson
+++ b/data/890/455/985/890455985.geojson
@@ -112,6 +112,9 @@
     },
     "wof:country":"PH",
     "wof:created":1469052988,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ae66370c2969b41dad9fa91afbdcc7fc",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":890455985,
-    "wof:lastmodified":1566681974,
+    "wof:lastmodified":1582346802,
     "wof:name":"San Isidro",
     "wof:parent_id":1108699707,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.