### PR TITLE
Remove lbl:bbox properties on megacity records

### DIFF
--- a/data/421/168/921/421168921.geojson
+++ b/data/421/168/921/421168921.geojson
@@ -10,7 +10,6 @@
     "geom:latitude":7.101528,
     "geom:longitude":125.586451,
     "iso:country":"PH",
-    "lbl:bbox":"125.59278,7.05306,125.63278,7.09306",
     "lbl:latitude":7.073765,
     "lbl:longitude":125.612,
     "lbl:max_zoom":13.0,
@@ -437,7 +436,7 @@
         }
     ],
     "wof:id":421168921,
-    "wof:lastmodified":1608689809,
+    "wof:lastmodified":1610153489,
     "wof:megacity":1,
     "wof:name":"Davao City",
     "wof:parent_id":1108698611,

--- a/data/421/175/823/421175823.geojson
+++ b/data/421/175/823/421175823.geojson
@@ -10,7 +10,6 @@
     "geom:latitude":10.323817,
     "geom:longitude":123.864426,
     "iso:country":"PH",
-    "lbl:bbox":"123.87071,10.29672,123.91071,10.33672",
     "lbl:latitude":10.296323,
     "lbl:longitude":123.898304,
     "lbl:max_zoom":13.0,
@@ -428,7 +427,7 @@
         }
     ],
     "wof:id":421175823,
-    "wof:lastmodified":1608689809,
+    "wof:lastmodified":1610153491,
     "wof:megacity":1,
     "wof:name":"Cebu",
     "wof:parent_id":890432909,

--- a/data/890/429/511/890429511.geojson
+++ b/data/890/429/511/890429511.geojson
@@ -13,7 +13,6 @@
     "gn:fcode":"PPLA2",
     "gn:population":457623,
     "iso:country":"PH",
-    "lbl:bbox":"122.05389,6.89028,122.09389,6.93028",
     "lbl:latitude":6.904724,
     "lbl:longitude":122.075985,
     "lbl:max_zoom":13.0,
@@ -349,7 +348,7 @@
         }
     ],
     "wof:id":890429511,
-    "wof:lastmodified":1608689808,
+    "wof:lastmodified":1610153499,
     "wof:megacity":1,
     "wof:name":"Zamboanga",
     "wof:parent_id":1108699889,


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1918

This PR removes the `lbl:bbox` property on megacity locality records. The `lbl:bbox` properties we're created when these records contained Point geometries, which should have been removed as part of ~1918.

If this PR looks okay, I'll merge this PR and add commits to other repos.